### PR TITLE
fix: improve text visibility in hero-gradient section

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -111,6 +111,15 @@ div[class*='language-'] {
 /* Hero section gradient background */
 .hero-gradient {
   background: linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%);
+  color: #e2e8f0;
+}
+
+.hero-gradient h2 {
+  color: #ffffff;
+}
+
+.hero-gradient p {
+  color: #cbd5e1;
 }
 
 /* Responsive container */


### PR DESCRIPTION
## Summary
Fixes text visibility issue in the hero-gradient section where black text was invisible against the dark gradient background.

## Issue
The "Ready to Work Together?" section on the homepage had black text on a dark blue/purple gradient background, making it unreadable.

## Changes Made
- Set base text color to light gray (`#e2e8f0`) for readability
- Set h2 headings to white (`#ffffff`) for prominence
- Set paragraph text to lighter gray (`#cbd5e1`) for proper contrast

## Visual Impact
**Before**: Black text invisible on dark gradient
**After**: White/light gray text clearly visible on dark gradient

## Testing
- ✅ Validation passes: `npm run validate`
- ✅ Text is now visible and readable against the dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)