### PR TITLE
fix: deploy workflow should run after release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
     branches:
       - main
   workflow_dispatch:
@@ -18,11 +21,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Only deploy if release workflow succeeded or was skipped
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'skipped' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main  # Always checkout main to get latest version after release
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem
The deployment and release workflows were running in parallel when code was pushed to `main`. This meant the deployment would sometimes build with the **old version number** before semantic-release had a chance to update it.

## Solution
Changed the deployment workflow to trigger **after** the release workflow completes using `workflow_run`.

## Changes Made
- Changed trigger from `on: push` to `on: workflow_run`
- Deploy now waits for "Release" workflow to complete
- Added condition to only deploy on success or skip
- Checkout always uses `main` ref to get latest version after semantic-release
- Preserved `workflow_dispatch` for manual deployments

## Workflow Order (After This Fix)
```
Push to main
    ↓
1. Release workflow runs (semantic-release bumps version)
    ↓
2. Deploy workflow triggers (uses updated version)
    ↓
3. Site deployed with correct version ✅
```

## Testing
- ✅ Validation passes: `npm run validate`
- ✅ Workflow syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)