### PR TITLE
fix: enable package.json version updates in semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,6 +10,12 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],


### PR DESCRIPTION
## Problem
Semantic-release was not updating the version in `package.json` and `package-lock.json`. The version remained at 1.0.0 even after releases were created.

## Root Cause
We previously removed the `@semantic-release/npm` plugin entirely to prevent npm publishing. However, this plugin is **also responsible for updating the version** in package.json and package-lock.json.

The `@semantic-release/git` plugin commits files but doesn't update versions.

## Solution
Re-added the `@semantic-release/npm` plugin with `npmPublish: false` configuration.

## Changes Made
- Added `@semantic-release/npm` plugin to `.releaserc.json`
- Configured with `"npmPublish": false` to skip npm registry publishing
- Plugin now updates package.json and package-lock.json versions
- Still protected by `"private": true` in package.json (double protection)

## How It Works Now
- ✅ Updates package.json version
- ✅ Updates package-lock.json version  
- ✅ Commits updated files to git
- ❌ Does NOT publish to npm (`npmPublish: false`)
- ❌ Double protection (`"private": true`)

## Testing
- ✅ Validation passes: `npm run validate`
- ✅ Configuration follows semantic-release best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)