### PR TITLE
chore: remove redundant validation from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate blog post styles
-        run: npm run validate
-
       - name: Build with VitePress
         run: npm run build
 


### PR DESCRIPTION
## Summary

Removes the redundant `npm run validate` step from the deploy workflow to dramatically reduce deploy times.

## Changes

- Removed `npm run validate` step from `.github/workflows/deploy.yml`
- Validation is already performed in PR validation workflow before merge
- Deploy workflow now only runs `npm run build`

## Performance Impact

**Before:**
- Deploy time: ~10 minutes
- Redundant validation included:
  - Style validation (fast)
  - License validation (fast)  
  - Accessibility tests with Playwright + axe-core (~9 minutes)

**After:**
- Expected deploy time: **~30-60 seconds**
- ~90% reduction in deploy time
- Lower GitHub Actions compute usage

## Rationale

Since all PRs must pass the full validation workflow before being merged to `main`, running validation again during deploy is:
- ❌ Redundant (already validated)
- ❌ Wasteful (GitHub Actions minutes)
- ❌ Slow (10 minute deploys)

The deploy workflow should focus on building and deploying the already-validated code.

## Testing

- [x] Verified PR validation workflow still runs full validation
- [ ] Will verify deploy time after merge (expecting <1 minute)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)