### PR TITLE
fix: configure git credentials for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fixes the semantic-release workflow hanging issue by properly configuring git authentication.

## Problem

The release workflow was hanging indefinitely on the semantic-release step. Investigation revealed that:

1. Checkout action used `persist-credentials: false` which removed git credentials
2. semantic-release's `@semantic-release/git` plugin tried to commit and push without authentication
3. Git operations hung waiting for credentials that would never come
4. Workflow had to be manually cancelled after 8+ minutes

**Evidence from logs:**
```
[5:35:36 PM] [semantic-release] [@semantic-release/git] › ℹ  Found 3 file(s) to commit
# ... 8 minutes of silence ...
# Hung forever
```

## Solution

Changed the checkout configuration from:
```yaml
persist-credentials: false
```

To:
```yaml
token: ${{ secrets.GH_TOKEN }}
```

This simple one-line change:
- ✅ Persists git credentials after checkout
- ✅ Automatically configures git to use GH_TOKEN for authentication  
- ✅ Allows semantic-release to commit and push successfully
- ✅ Follows the proven pattern from lib.no project

## Testing

- [x] Commit created and pushed successfully
- [ ] Will verify workflow completes in ~30-45 seconds (vs 8+ minutes hang)
- [ ] Will verify semantic-release creates tag and GitHub release
- [ ] Will verify deploy workflow triggers after release completes

## Expected Behavior After Merge

When this PR is merged, the release workflow will:
1. Analyze commits since v1.0.4
2. Detect the `feat: implement axe-core accessibility compliance testing` commit
3. Create version v1.1.0 (MINOR bump)
4. Update CHANGELOG.md, package.json, package-lock.json
5. Commit and push changes ← **This will now work!**
6. Create git tag v1.1.0
7. Create GitHub release
8. Comment on related PRs
9. Trigger deploy workflow

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)