### PR TITLE
fix: simplify semantic-release config to use default commit message

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,8 +18,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"]
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary

Second attempt to fix the semantic-release workflow hanging issue by simplifying the configuration to match the working lib.no pattern.

## Background

PR #11 fixed the git credentials issue, but **the workflow still hangs** at the same place:
```
[semantic-release] [@semantic-release/git] › ℹ  Found 3 file(s) to commit
# ... hangs indefinitely ...
```

## Root Cause Analysis

Comparing with the working lib.no configuration revealed a difference in the `@semantic-release/git` plugin config.

**Current config** (causing hang):
```json
"@semantic-release/git": {
  "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
  "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
}
```

**lib.no config** (working):
```json
"@semantic-release/git": {
  "assets": ["CHANGELOG.md", "package.json", "package-lock.json", "gradle.properties"]
}
```

The custom commit message template may be causing issues with:
- Variable interpolation
- Git waiting for input
- Multiline string handling

## Solution

Remove the custom `message` parameter and let semantic-release use its default commit message format.

**Change:**
```diff
 "@semantic-release/git": {
-  "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-  "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+  "assets": ["CHANGELOG.md", "package.json", "package-lock.json"]
 }
```

## Expected Behavior

With the simplified config, semantic-release will:
1. Use its built-in default commit message
2. Commit the release files without hanging
3. Push to GitHub successfully
4. Complete the release in ~30-45 seconds

## Testing

- [x] Commit created successfully
- [ ] Will verify workflow completes without hanging
- [ ] Will verify release is created successfully

## If This Still Hangs

Next debugging steps:
1. Add `DEBUG=semantic-release:*` to workflow for verbose logging
2. Check if `@semantic-release/npm` plugin is causing issues
3. Try running semantic-release locally to isolate the problem
4. Check GitHub token permissions more thoroughly

Part of #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)