### PR TITLE
feat: add manual trigger capability to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Added `workflow_dispatch` trigger to the release workflow to enable manual triggering when automatic triggers fail or when manual control is needed.

## Changes
- Added `workflow_dispatch:` trigger to `.github/workflows/release.yml`

## Context
After merging PR #12, the release workflow did not automatically trigger. This enhancement adds the ability to manually trigger the release workflow via the GitHub Actions UI when needed.

## Related Issues
Fixes #13

## Testing
- [ ] Verify workflow can be manually triggered via GitHub Actions UI
- [ ] Test that automatic triggers still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)