### PR TITLE
fix: configure git user for semantic-release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,8 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: npx semantic-release


### PR DESCRIPTION
## Summary
Added git author and committer environment variables to the Release step to ensure semantic-release can properly create commits.

## Problem
Semantic-release workflow has been hanging at the commit step. After comparing with the working lib.no workflow and testing previous fixes:
1. ✅ Fixed git credentials (PR #11) - Still hung
2. ✅ Simplified config (PR #12) - Still hung
3. ⏳ This PR: Configure git user information

## Changes
Added the following environment variables to the Release step:
- `GIT_AUTHOR_NAME: github-actions[bot]`
- `GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com`
- `GIT_COMMITTER_NAME: github-actions[bot]`
- `GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com`

## Root Cause
Without git user configuration, semantic-release hangs when attempting to create commits because git doesn't know who the author/committer should be.

## Testing
- [ ] Merge PR and let release workflow trigger automatically
- [ ] Verify semantic-release completes without hanging
- [ ] Confirm release is created on GitHub

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)