### PR TITLE
fix: use correct token name for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -37,9 +37,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

Fixes the semantic-release workflow hanging issue by using the correct token name.

## Problem

The semantic-release workflow was hanging because it was referencing `secrets.GH_TOKEN`, but the actual secret configured in the repository is named `SEMANTIC_RELEASE_TOKEN`.

## Changes

- Changed `secrets.GH_TOKEN` to `secrets.SEMANTIC_RELEASE_TOKEN` in checkout step
- Changed `secrets.GH_TOKEN` to `secrets.SEMANTIC_RELEASE_TOKEN` in release step  
- Removed redundant git author/committer environment variables (not needed)

## Testing

- [ ] Verify workflow runs successfully after merge
- [ ] Confirm semantic-release completes without hanging

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)