### PR TITLE
fix: revert to GH_TOKEN in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -37,5 +37,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

Reverts the token name back to GH_TOKEN to match the actual repository secret.

## Problem

PR #16 incorrectly changed the token name from `GH_TOKEN` to `SEMANTIC_RELEASE_TOKEN`, but the actual secret configured in the repository is named `GH_TOKEN`.

This caused the release workflow to fail with:
```
Input required and not supplied: token
```

## Solution

Revert both token references back to `GH_TOKEN`:
- Checkout step: `token: ${{ secrets.GH_TOKEN }}`
- Release step: `GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}`

## Testing

- [ ] Verify release workflow runs successfully after merge
- [ ] Confirm semantic-release can authenticate and create releases

## Impact

**HIGH** - This unblocks the entire release pipeline that has been broken since PR #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)