### PR TITLE
refactor: use Husky's built-in CI detection instead of --no-verify

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/configure-pages@v4
 
       - name: Install dependencies
+        env:
+          HUSKY: 0
         run: npm ci
 
       - name: Build with VitePress

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,6 +27,8 @@ jobs:
           cache: npm
 
       - name: Install dependencies
+        env:
+          HUSKY: 0
         run: npm ci
 
       - name: Validate blog styles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           cache: npm
 
       - name: Install dependencies
+        env:
+          HUSKY: 0
         run: npm ci
 
       - name: Verify the integrity of provenance attestations and registry signatures
@@ -38,4 +40,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          HUSKY: 0
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,8 +18,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "gitCommitOptions": "--no-verify"
+        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"]
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
Closes #22

## Summary

- Replaced `--no-verify` workaround with Husky's official `HUSKY=0` environment variable
- Added `HUSKY: 0` to all GitHub Actions workflows (release.yml, deploy.yml, pr-validation.yml)
- Removed `gitCommitOptions: "--no-verify"` from semantic-release configuration

## Why This Change?

The previous solution used `--no-verify` to skip git hooks during semantic-release commits in CI. However, Husky's official documentation recommends using the `HUSKY=0` environment variable to disable hooks in CI environments.

**Benefits:**
- ✅ Uses official Husky-recommended approach
- ✅ All hooks consistently skipped across all CI workflows
- ✅ No manual `--no-verify` flags needed
- ✅ Hooks still run locally for developers
- ✅ Cleaner and more maintainable solution

## Investigation Findings

Husky does **NOT** automatically detect CI environments based on the `CI` variable. From Husky documentation:
> "To avoid installing Git Hooks on CI servers or in Docker, use `HUSKY=0`."

The `CI=true` variable set by GitHub Actions is ignored by Husky, which is why hooks were running during semantic-release commits.

## Test Plan

- [x] Local commit validation still runs (verified during commit)
- [ ] Release workflow skips hooks with `HUSKY=0`
- [ ] Deploy workflow skips hooks with `HUSKY=0`
- [ ] PR validation workflow skips hooks with `HUSKY=0`
- [ ] Semantic-release can create commits without hook failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)