### PR TITLE
docs: add context awareness principle to best practices

### DIFF
--- a/docs/claude/best-practices.md
+++ b/docs/claude/best-practices.md
@@ -19,6 +19,43 @@ Claude Code is a powerful tool, but it is not infallible:
 
 Your expertise combined with Claude's capabilities produces the best results. Never blindly accept solutions - engage, question, and validate.
 
+### Always Check Current Context Before Operations
+
+**IMPORTANT: Know where you are before you act!**
+
+Claude should ALWAYS verify the current context before performing operations:
+
+#### Before Git Operations
+- ✅ **Check current branch**: Run `git branch --show-current` before:
+  - Creating commits (`git commit`)
+  - Creating PRs (`gh pr create`)
+  - Pushing changes (`git push`)
+  - Merging or rebasing
+- ✅ **Verify git status**: Run `git status` to understand:
+  - What files are staged/unstaged
+  - Whether you're ahead/behind remote
+  - Current branch state
+
+#### Before File Operations
+- ✅ **Check current directory**: Run `pwd` when path context matters
+- ✅ **Verify file paths**: Use absolute paths or confirm relative path context
+- ✅ **List directory contents**: Use `ls` or glob patterns to verify structure
+
+#### Why This Matters
+- ❌ **Prevents mistakes** like creating PRs from wrong branch
+- ❌ **Prevents confusion** about which files are being modified
+- ❌ **Prevents errors** from working in wrong directory
+- ✅ **Builds confidence** that operations will succeed
+- ✅ **Catches issues early** before they cause problems
+
+**Example mistakes this prevents:**
+- Trying to `gh pr create` while on `main` branch
+- Committing to wrong feature branch
+- Running build/test commands in wrong directory
+- Editing files in unexpected locations
+
+**Make it a habit:** Context checks are quick and prevent costly mistakes.
+
 ---
 
 ## Communication


### PR DESCRIPTION
Part of #30

## Summary

Added new core principle to best-practices.md: **"Always Check Current Context Before Operations"**

This addresses the real issue we encountered where attempting to create a PR without first checking the current branch led to confusion and errors.

## What Was Added

### Before Git Operations
- Check current branch: `git branch --show-current`
- Check git status to understand staged/unstaged files
- Critical before: commits, PRs, pushes, merges, rebases

### Before File Operations  
- Check current directory: `pwd` when path context matters
- Verify file paths (use absolute paths or confirm relative path context)
- List directory contents to verify structure

### Why This Matters
- **Prevents mistakes** like creating PRs from wrong branch
- **Prevents confusion** about which files are being modified
- **Prevents errors** from working in wrong directory
- **Builds confidence** that operations will succeed
- **Catches issues early** before they cause problems

## Real Examples Documented

The guideline includes real examples of mistakes this prevents:
- Trying to `gh pr create` while on `main` branch (the exact issue we had!)
- Committing to wrong feature branch
- Running build/test commands in wrong directory
- Editing files in unexpected locations

## Files Changed

- `docs/claude/best-practices.md` - Added comprehensive Context Awareness section to Core Principles

**Stats**: 1 file changed, 37 insertions(+)

## Testing

- [x] All validation checks pass (styles, licenses, accessibility)
- [x] Documentation is clear and actionable
- [x] Examples are based on real scenarios we encountered

## Impact

This guideline will help prevent context-related mistakes by establishing the habit of always verifying:
- Which branch am I on?
- Which directory am I in?
- What is the current state?

**Make it a habit: Context checks are quick and prevent costly mistakes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>