### PR TITLE
feat: improve 404 Viking Bear image scaling for 4K displays

### DIFF
--- a/docs/.vitepress/theme/components/NotFound.vue
+++ b/docs/.vitepress/theme/components/NotFound.vue
@@ -3,12 +3,12 @@
     <div class="max-w-3xl mx-auto">
       <!-- Viking Bear Image -->
       <div class="flex flex-col items-center mb-12">
-        <picture class="block w-full max-w-xs sm:max-w-sm">
+        <picture class="flex justify-center w-full max-h-[40vh]">
           <source srcset="/images/404_viking_bear.webp" type="image/webp" />
           <img
             src="/images/404_viking_bear.png"
             alt="A Viking and a bear sitting together by a campfire at night, having fallen asleep while building the page - symbolizing collaboration across differences"
-            class="w-full h-auto"
+            class="w-auto h-auto max-h-[40vh] mx-auto"
           />
         </picture>
         <p class="text-xs text-[var(--vp-c-text-3)] mt-2 italic">


### PR DESCRIPTION
## Summary
- Replaced fixed max-width constraints with viewport height-based scaling (40vh)
- Updated image sizing to maintain aspect ratio with proper centering
- Viking Bear now scales appropriately across all display sizes

## Changes
- **NotFound.vue**: Updated picture and img elements to use Tailwind's `max-h-[40vh]` and flexbox centering

## Test Plan
- [x] Tested on localhost at various viewport sizes
- [x] Verified image scales from ~432px (1080p) to ~864px (4K)
- [x] Confirmed centering works when browser window is scaled down
- [x] All validation hooks passed (styles, licenses, accessibility)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)