### PR TITLE
fix: add missing checkout step in deploy workflow check-release job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,11 @@ jobs:
     outputs:
       should-deploy: ${{ steps.check.outputs.should-deploy }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Check if release was created
         id: check
         run: |


### PR DESCRIPTION
## Summary
Fixes the GitHub Pages deployment workflow that was always skipping the build and deploy steps. The `check-release` job was attempting to run git commands without first checking out the repository, causing it to fail and always set `should-deploy=false`.

## Problem
The deployment workflow logs showed:
```
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.
No release tag found - skipping deployment
```

This occurred because the `check-release` job tried to run `git ls-remote` to detect release tags without first checking out the code.

## Solution
Added a checkout step with `fetch-depth: 0` to the `check-release` job, enabling it to properly query the git repository for release tags created by semantic-release.

## Impact
- ✅ Deployment workflow will now correctly detect release tags
- ✅ Successful releases will trigger GitHub Pages deployment
- ✅ Manual deployments (workflow_dispatch) continue to work

## Testing
- [x] All validation hooks pass
- [x] Workflow syntax is valid
- [ ] Will be fully tested when merged and next release is created

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)