### PR TITLE
fix: re-introduce version number in footer

### DIFF
--- a/docs/.vitepress/theme/components/Footer.vue
+++ b/docs/.vitepress/theme/components/Footer.vue
@@ -11,7 +11,7 @@
         <a href="mailto:contact@bancs.no">contact@bancs.no</a>
       </div>
       <div class="attribution">
-        Built with VitePress and Tailwind CSS · Developed with Claude by Anthropic
+        Built with VitePress and Tailwind CSS · <a href="https://github.com/BANCS-Norway/home/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer">{{ version }}</a> · Developed with Claude by Anthropic
       </div>
       <div class="copyright">
         Copyright © {{ new Date().getFullYear() }} BANCS AS
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-// Empty script setup to enable template expressions
+import { version } from '../../../../package.json'
 </script>
 
 <style scoped>
@@ -74,6 +74,15 @@
   margin-bottom: 0.25rem;
   font-size: 0.8rem;
   color: var(--vp-c-text-3);
+}
+
+.attribution a {
+  color: var(--vp-c-brand);
+  text-decoration: underline;
+}
+
+.attribution a:hover {
+  text-decoration: none;
 }
 
 .copyright {


### PR DESCRIPTION
## Summary

Re-introduces the version number display in the footer that was previously removed. The version now appears in the attribution line between the tech stack information and Claude attribution, with a clickable link to the CHANGELOG.

## Changes

- Import version from package.json in Footer.vue
- Display version (format: "1.5.0") in the attribution line
- Link version to CHANGELOG.md on GitHub (opens in new tab)
- Add consistent link styling matching other footer links (brand color, underline, hover effect)

## Test Plan

- [x] Build passes successfully
- [x] All validation scripts pass (styles, licenses, accessibility)
- [x] Version displays correctly in footer
- [x] Link to CHANGELOG works and opens in new tab
- [x] Styling matches existing footer links
- [x] Version updates automatically from package.json

## Closes

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)