### PR TITLE
chore(ci): check latest main commit for release tags in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,12 @@ jobs:
             echo "Manual trigger - deploying"
             echo "should-deploy=true" >> $GITHUB_OUTPUT
           else
-            # Get the commit SHA from the workflow run that triggered this
-            COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
-            echo "Checking if commit $COMMIT_SHA has a release tag..."
+            # Get the latest commit on main branch (where semantic-release creates the tag)
+            LATEST_COMMIT=$(git rev-parse origin/main)
+            echo "Checking if latest commit on main ($LATEST_COMMIT) has a release tag..."
 
             # Check if this commit has a tag (semantic-release creates tags)
-            TAG=$(git ls-remote --tags origin | grep "$COMMIT_SHA" | grep -v '\^{}' | awk '{print $2}' | sed 's|refs/tags/||' || echo "")
+            TAG=$(git ls-remote --tags origin | grep "$LATEST_COMMIT" | grep -v '\^{}' | awk '{print $2}' | sed 's|refs/tags/||' || echo "")
 
             if [ -n "$TAG" ]; then
               echo "Release tag found: $TAG - will deploy"


### PR DESCRIPTION
## Summary

- Fixes deploy workflow to check the correct commit for release tags
- Changes from checking `workflow_run.head_sha` to checking latest commit on `origin/main`
- This resolves the issue where GitHub Pages deployments were always skipped

## Problem

The deploy workflow was checking `workflow_run.head_sha` (the commit that triggered the release workflow) for tags. However, semantic-release creates a new commit with `[skip ci]` and tags that commit instead. This meant the tag check always failed and deployments were skipped.

## Solution

Now checks `git rev-parse origin/main` to get the latest commit on main, which will be the semantic-release commit with the tag.

## Test plan

- [x] Verify workflow file syntax is correct
- [ ] Merge PR and wait for next release
- [ ] Verify deploy workflow finds the tag and runs the deployment
- [ ] Confirm GitHub Pages site is updated

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)