### PR TITLE
chore: add worktrees directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ playwright/.cache/
 # Lock files (keep package-lock.json for consistency)
 # pnpm-lock.yaml
 # yarn.lock
+
+# Git worktrees
+worktrees/


### PR DESCRIPTION
## Summary

This PR adds the `worktrees/` directory to `.gitignore` to prevent it from appearing as untracked in git status output.

### Changes

- Added `worktrees/` entry to `.gitignore` with a descriptive comment
- The worktrees directory is now properly ignored by git

### Why This Change?

The `worktrees/` directory is used for managing multiple git worktrees locally and is specific to each developer's setup. It should not be tracked in the repository as it:

- Clutters `git status` output when present
- Could accidentally be committed 
- Contains developer-specific local state
- Follows standard git worktree best practices

### Impact

- Clean `git status` output
- Prevents accidental commits of worktree directories
- Follows git worktree conventions

## Test plan

- [x] Verified `worktrees/` directory no longer appears in `git status`
- [x] Pre-commit hooks passed (style validation, license validation, accessibility tests)
- [x] `.gitignore` syntax is correct

## Related Issues

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)