### PR TITLE
docs: add cross-reference between CLAUDE.md Philosophy and best-practices.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ Claude Code is a powerful AI assistant that enhances human productivity and code
 - **Transparency**: We're open about our use of AI tools in development
 - **Question and Validate**: Always maintain healthy skepticism and verify Claude's solutions. If something doesn't look right, investigate and challenge it.
 
+> For more detailed principles and practices, see [Best Practices](./docs/claude/best-practices.md).
+
 ## Documentation
 
 This guide has been split into focused documents for easier navigation:


### PR DESCRIPTION
## Summary

This PR adds a cross-reference at the end of the Philosophy section in CLAUDE.md that directs users to the Best Practices documentation for more detailed guidance.

### Changes

- Added a blockquote cross-reference after the Philosophy section
- Links to `docs/claude/best-practices.md` for expanded principles and practices

### Why This Change?

The "Question and Validate" principle and other philosophy points are mentioned briefly in CLAUDE.md but have more detailed coverage in best-practices.md. Adding this cross-reference:

- 🔗 Improves discoverability of detailed best practices
- 📚 Helps users find deeper guidance beyond the quick overview
- ✅ Creates natural navigation flow from high-level to detailed docs
- 🎯 Encourages users to explore comprehensive documentation

### Visual Impact

The blockquote format provides a clear visual indicator without disrupting the existing document structure:

```markdown
> For more detailed principles and practices, see [Best Practices](./docs/claude/best-practices.md).
```

## Test plan

- [x] Verified link path is correct (`docs/claude/best-practices.md` exists)
- [x] Cross-reference placement feels natural after Philosophy section
- [x] Pre-commit hooks passed (style validation, license validation, accessibility tests)
- [x] Document structure and flow remain intact

## Related Issues

Closes #56

Part of #30 (ongoing CLAUDE.md improvements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)