### PR TITLE
fix: add missing blog post to blog index

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -6,6 +6,19 @@ Welcome to the BANCS blog, where we share insights about software development, A
 
 <BlogCard>
 
+### [The Pause Isn't Procrastination - It's Part of Your Process](/blog/pause-not-procrastination)
+**Date**: October 26, 2025
+
+How AI-assisted development removed all natural pauses from our workflow - and why we need to intentionally build them back in. A meditation on creativity, breakthrough moments, and the wisdom of stepping away.
+
+**Topics**: AI Development, Creativity, Work-Life Balance, Developer Wellbeing
+
+[Read more →](/blog/pause-not-procrastination)
+
+</BlogCard>
+
+<BlogCard>
+
 ### [From Problem-Solver to Systems Builder](/blog/from-problem-solver-to-systems-builder)
 **Date**: September 2024
 


### PR DESCRIPTION
## Summary

- Added "The Pause Isn't Procrastination - It's Part of Your Process" to the top of the blog index
- The blog post was published but wasn't listed in `docs/blog/index.md`
- Maintains reverse chronological order (newest first)

## Changes

- Updated `docs/blog/index.md` to include the new blog post entry
- Added proper formatting, date (October 26, 2025), description, and topics

## Test Plan

- [x] Blog post appears at the top of the index
- [x] Link to `/blog/pause-not-procrastination` works correctly
- [x] Formatting matches existing blog cards
- [x] All validation checks passed (styles, licenses, accessibility)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)