### PR TITLE
style: add gradient background CTA section with reusable component

### DIFF
--- a/docs/.vitepress/theme/components/CustomButton.vue
+++ b/docs/.vitepress/theme/components/CustomButton.vue
@@ -1,7 +1,10 @@
 <template>
   <a
     :href="href"
-    class="inline-flex items-center px-8 py-3 rounded-lg font-semibold text-lg transition-all duration-200 bg-gradient-to-r from-purple-400 to-pink-400 text-slate-900 no-underline border-2 border-purple-400/30 shadow-lg shadow-purple-400/40 hover:scale-105 hover:shadow-xl hover:shadow-purple-400/60 hover:from-purple-300 hover:to-pink-300"
+    :aria-label="ariaLabel"
+    :title="title"
+    :rel="rel"
+    class="inline-flex items-center px-8 py-3 rounded-lg font-semibold text-lg transition-all duration-200 bg-linear-to-r from-purple-400 to-pink-400 text-slate-900 no-underline border-2 border-purple-400/30 shadow-lg shadow-purple-400/40 hover:scale-105 hover:shadow-xl hover:shadow-purple-400/60 hover:from-purple-300 hover:to-pink-300"
   >
     {{ text }}
   </a>
@@ -11,5 +14,8 @@
 defineProps<{
   href: string
   text: string
+  ariaLabel?: string
+  title?: string
+  rel?: string
 }>()
 </script>

--- a/docs/.vitepress/theme/components/GradientCTA.vue
+++ b/docs/.vitepress/theme/components/GradientCTA.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="bg-linear-to-br from-slate-900 to-indigo-950 py-16 mt-16">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h2 class="text-white border-0! pt-0! mt-0!">{{ heading }}</h2>
+
+      <p class="text-slate-300">{{ description }}</p>
+
+      <div class="mt-8">
+        <CustomButton
+          :href="buttonHref"
+          :text="buttonText"
+          :aria-label="buttonAriaLabel"
+          :title="buttonTitle"
+          :rel="buttonRel"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    heading: string
+    description: string
+    buttonHref?: string
+    buttonText?: string
+    buttonAriaLabel?: string
+    buttonTitle?: string
+  }>(),
+  {
+    buttonHref: 'mailto:contact@bancs.no',
+    buttonText: 'Contact Us'
+  }
+)
+
+// Set rel attribute for regular links, but not for mailto links
+const buttonRel = computed(() => {
+  return props.buttonHref.startsWith('mailto:') ? undefined : 'noopener'
+})
+</script>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -8,6 +8,7 @@ import ProjectCard from './components/ProjectCard.vue'
 import BlogCard from './components/BlogCard.vue'
 import CustomButton from './components/CustomButton.vue'
 import DisclaimerBox from './components/DisclaimerBox.vue'
+import GradientCTA from './components/GradientCTA.vue'
 
 export default {
   extends: DefaultTheme,
@@ -17,6 +18,7 @@ export default {
     app.component('BlogCard', BlogCard)
     app.component('CustomButton', CustomButton)
     app.component('DisclaimerBox', DisclaimerBox)
+    app.component('GradientCTA', GradientCTA)
   },
   Layout: () => {
     return h(DefaultTheme.Layout, null, {

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -45,20 +45,9 @@ We typically respond to inquiries within 24-48 hours during business days.
 
 ---
 
-<div class="text-center mt-12">
-
-### Let's Build Something Great Together
-
-<CustomButton href="mailto:contact@bancs.no" text="Contact Us" />
-
-</div>
-
-<style scoped>
-.text-center {
-  text-align: center;
-}
-
-.mt-12 {
-  margin-top: 3rem;
-}
-</style>
+<GradientCTA
+  heading="Let's Build Something Great Together"
+  description="Ready to discuss your project or explore how we can work together? Get in touch and let's start the conversation."
+  buttonAriaLabel="Send email to BANCS at contact@bancs.no"
+  buttonTitle="Send us an email to discuss your project"
+/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,18 +76,11 @@ We specialize in:
 
 </div>
 
-<!-- Call-to-Action Gradient Section -->
-<div class="bg-gradient-to-br from-slate-900 to-indigo-950 py-16 mt-16">
-<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-
-<h2 class="text-white border-0! pt-0! mt-0!">Ready to Work Together?</h2>
-
-<p class="text-slate-300">Whether you have a project in mind or just want to discuss technology, we'd love to hear from you.</p>
-
-<div class="mt-8">
-<CustomButton href="/contact" text="Contact Us" />
-</div>
-
-</div>
-</div>
+<GradientCTA
+  heading="Ready to Work Together?"
+  description="Whether you have a project in mind or just want to discuss technology, we'd love to hear from you."
+  buttonHref="/contact"
+  buttonAriaLabel="Navigate to contact page"
+  buttonTitle="Visit our contact page to get in touch"
+/>
 


### PR DESCRIPTION
## Summary

This PR adds a gradient background section to the contact page for visual consistency with the homepage, while creating a reusable `GradientCTA` component to maintain DRY principles.

### Key Changes

- ✅ **New Component**: `GradientCTA.vue` - Reusable gradient CTA section
- ✅ **Contact Page**: Added gradient background matching homepage
- ✅ **Homepage**: Refactored to use new component
- ✅ **Accessibility**: Enhanced `CustomButton` with semantic attributes
- ✅ **Tailwind v4**: Updated gradient syntax (`bg-linear-to-*`)

### Component Features

- Flexible props for heading, description, button text/href
- Sensible defaults (`mailto:contact@bancs.no`, "Contact Us")
- Optional semantic attributes (`aria-label`, `title`)
- Smart `rel="noopener"` handling (excluded for `mailto:` links)
- 100% Tailwind CSS utility classes (no custom CSS)

### Visual Consistency

Both pages now feature the same gradient background styling while maintaining unique, contextual content:

- **Homepage**: "Ready to Work Together?" → navigates to `/contact`
- **Contact**: "Let's Build Something Great Together" → opens email client

### Accessibility Improvements

- Added `aria-label` for screen reader context
- Added `title` attributes for hover tooltips
- Smart `rel` attribute handling based on link type

### Before/After

**Before (Contact Page)**:
- Plain white background
- Simple centered section with scoped CSS

**After (Contact Page)**:
- Gradient background (slate-900 → indigo-950)
- Proper responsive padding and spacing
- Tailwind utility classes only
- Semantic attributes for accessibility

## Test Plan

- [x] Contact page displays gradient background correctly
- [x] Homepage gradient section still works
- [x] Both pages render with unique content
- [x] Hover tooltips display on buttons
- [x] `mailto:` link works on contact page (no `rel` attribute)
- [x] `/contact` link works on homepage (includes `rel="noopener"`)
- [x] No Tailwind v4 gradient warnings
- [x] Responsive layout works on mobile/tablet/desktop
- [x] Light/dark mode compatibility

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)