### PR TITLE
chore: configure semantic-release to trigger versions on style commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,14 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "style", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",

--- a/docs/claude/commit-guidelines.md
+++ b/docs/claude/commit-guidelines.md
@@ -16,8 +16,8 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) a
 
 - `feat`: New feature → **MINOR version bump** (1.0.0 → 1.1.0)
 - `fix`: Bug fix → **PATCH version bump** (1.0.0 → 1.0.1)
+- `style`: Visual/CSS changes → **PATCH version bump** (1.0.0 → 1.0.1)
 - `docs`: Documentation changes → No version bump
-- `style`: Formatting, typos → No version bump
 - `refactor`: Code restructuring → No version bump
 - `test`: Adding tests → No version bump
 - `chore`: Maintenance tasks → No version bump


### PR DESCRIPTION
## Summary

- Add custom releaseRules to @semantic-release/commit-analyzer
- Configure style commits to trigger patch version bumps
- Update commit-guidelines.md to reflect new behavior

## Rationale

`style:` commits represent user-visible CSS/visual changes that should trigger deployments and appear in CHANGELOG, aligning with our strategy that user-visible changes should create versions.

## Changes

- `.releaserc.json`: Added custom release rules for style commits
- `docs/claude/commit-guidelines.md`: Updated documentation to reflect that style commits now trigger patch version bumps

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)