### PR TITLE
docs: establish commit type guidelines for consistent semantic versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,22 @@ After that, subsequent pushes can just use `git push`.
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) for semantic versioning:
 
-- `feat:` → Minor version (1.0.0 → 1.1.0)
-- `fix:` → Patch version (1.0.0 → 1.0.1)
+**Triggers Version Bump (Site Deployment):**
+> **ONLY for VitePress site changes**
+- `feat:` → Minor version (1.0.0 → 1.1.0) - New site features
+- `fix:` → Patch version (1.0.0 → 1.0.1) - Site bug fixes
+- `style:` → Patch version (1.0.0 → 1.0.1) - CSS/visual changes to site
 - `BREAKING CHANGE:` → Major version (1.0.0 → 2.0.0)
+
+**No Version Bump (Internal Changes):**
+> **For tooling, docs, configs, internal code**
+- `docs:` - Documentation only (CLAUDE.md, README, workflow docs)
+- `chore:` - Build/tooling/dependencies/configs
+- `refactor:` - Code restructuring (internal)
+- `test:` - Tests only
+- `ci:` - CI/CD changes
+
+**Key:** `style:` = visual changes (bump), `refactor:` = code changes (no bump)
 
 #### 💡 Optional Slash Commands
 

--- a/docs/claude/commit-guidelines.md
+++ b/docs/claude/commit-guidelines.md
@@ -14,13 +14,59 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) a
 
 ## Commit Types
 
-- `feat`: New feature → **MINOR version bump** (1.0.0 → 1.1.0)
-- `fix`: Bug fix → **PATCH version bump** (1.0.0 → 1.0.1)
-- `style`: Visual/CSS changes → **PATCH version bump** (1.0.0 → 1.0.1)
-- `docs`: Documentation changes → No version bump
-- `refactor`: Code restructuring → No version bump
-- `test`: Adding tests → No version bump
-- `chore`: Maintenance tasks → No version bump
+### Commits That Trigger Version Bumps (Site Deployments)
+
+**IMPORTANT**: Only use these commit types for changes that affect the VitePress site itself. Changes to tooling, documentation, or internal processes should use `chore:` or `docs:` instead.
+
+These commit types result in a new version and site deployment:
+
+- `feat`: New features or enhancements visible to site users → **MINOR version bump** (1.0.0 → 1.1.0)
+  - Example: `feat(blog): add search functionality`
+  - Example: `feat: add contact form validation`
+  - **Use for**: New site pages, features, components that users see
+
+- `fix`: Bug fixes that affect site functionality or appearance → **PATCH version bump** (1.0.0 → 1.0.1)
+  - Example: `fix(blog): correct code example in Vue post`
+  - Example: `fix: repair broken navigation links`
+  - **Use for**: Fixing site bugs, broken links, display issues
+
+- `style`: CSS/styling changes that affect visual appearance → **PATCH version bump** (1.0.0 → 1.0.1)
+  - Example: `style: convert Footer to Tailwind CSS utility classes`
+  - Example: `style: add gradient background to contact page`
+  - **Use for**: Visual/CSS changes to the site
+  - **Note**: This is for visual/CSS changes, NOT code formatting
+
+### Commits That Don't Trigger Version Bumps
+
+These commit types are for internal changes that don't affect the VitePress site:
+
+- `docs`: Documentation-only changes (CLAUDE.md, README, code comments, workflow docs) → No version bump
+  - Example: `docs: update git workflow documentation`
+  - Example: `docs: clarify commit guidelines`
+  - Example: `docs: update CONTRIBUTING.md`
+  - **Use for**: Any documentation that isn't part of the VitePress site content
+
+- `chore`: Build process, tooling, dependencies, maintenance, project configuration → No version bump
+  - Example: `chore: update dependencies`
+  - Example: `chore: add worktrees to .gitignore`
+  - Example: `chore: configure semantic-release`
+  - **Use for**: Tooling, configs, dependencies, internal processes
+
+- `refactor`: Code restructuring without changing functionality → No version bump
+  - Example: `refactor: extract reusable component`
+  - Example: `refactor: simplify authentication logic`
+  - **Note**: This is for internal code changes, NOT visual changes
+
+- `test`: Test-only changes → No version bump
+  - Example: `test: add unit tests for utility functions`
+
+- `ci`: CI/CD pipeline changes → No version bump
+  - Example: `ci: update deployment workflow`
+
+### Important Distinction: `style:` vs `refactor:`
+
+- **`style:`** = CSS/visual changes → **triggers version bump** → user-visible changes
+- **`refactor:`** = Code restructuring → **no version bump** → internal-only changes
 
 ## Breaking Changes
 


### PR DESCRIPTION
## Summary

Establishes clear commit type guidelines to ensure consistent semantic versioning and prevent confusion about when version bumps should occur.

### Key Changes

- **Updated `docs/claude/commit-guidelines.md`**:
  - Added prominent warning: Only use `feat:`/`fix:`/`style:` for VitePress site changes
  - Reorganized into "Triggers Version Bumps" and "No Version Bumps" sections
  - Added detailed examples and "Use for:" guidance for each type
  - Clarified `style:` (CSS/visual) vs `refactor:` (code restructuring) distinction

- **Updated `CLAUDE.md` quick reference**:
  - Added callout: "ONLY for VitePress site changes" under version bump types
  - Added callout: "For tooling, docs, configs, internal code" under no-bump types
  - Expanded descriptions with specific use cases

### Problem Solved

Previously, there was ambiguity about:
- When to use `style:` vs `refactor:`
- Which changes should trigger site deployments
- Whether documentation/tooling changes should bump versions

### Impact

✅ Clear guidelines prevent incorrect version bumps
✅ Developers understand exactly when to use each commit type
✅ Semantic versioning becomes predictable and consistent
✅ Documentation and tooling changes won't trigger unnecessary deployments

## Acceptance Criteria

All criteria from #78 completed:
- [x] Guidelines documented in `docs/claude/commit-guidelines.md`
- [x] Quick reference added to `CLAUDE.md`
- [x] Examples provided for each commit type
- [x] Clear distinction between `style:` and `refactor:` explained

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)