### PR TITLE
feat: add BlogHeading component for responsive mobile title wrapping

### DIFF
--- a/docs/.vitepress/theme/components/BlogHeading.vue
+++ b/docs/.vitepress/theme/components/BlogHeading.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="blog-heading mb-8">
+    <!-- Title with responsive wrapping at colon -->
+    <h1 class="text-3xl md:text-4xl font-bold text-slate-900 dark:text-white border-0! pt-0! mt-0! leading-tight">
+      <span v-if="mainTitle">{{ mainTitle }}</span><span v-if="subtitle" class="block md:inline"><span class="hidden md:inline">: </span><span class="text-slate-700 dark:text-slate-300">{{ subtitle }}</span></span>
+    </h1>
+
+    <!-- Metadata -->
+    <div class="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-sm text-slate-600 dark:text-slate-400">
+      <span v-if="publishDate"><strong>Published:</strong> {{ publishDate }}</span>
+      <span v-if="author"><strong>Author:</strong> {{ author }}</span>
+      <span v-if="readingTime"><strong>Reading Time:</strong> {{ readingTime }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+// BlogHeading component - displays blog post titles with responsive wrapping
+//
+// Props:
+// - title: The full blog post title (will be split at colon if present)
+// - publishDate: Publication date string
+// - author: Author name
+// - readingTime: Reading time estimate (e.g., "10 minutes")
+//
+// On mobile (<768px): Subtitle breaks to new line
+// On desktop (≥768px): Title and subtitle on same line with colon
+
+const props = withDefaults(defineProps<{
+  title: string
+  publishDate?: string
+  author?: string
+  readingTime?: string
+}>(), {
+  author: 'Benny (Bancs AS)'
+})
+
+// Split title at colon for responsive wrapping
+const mainTitle = computed(() => {
+  const colonIndex = props.title.indexOf(':')
+  if (colonIndex === -1) return props.title
+  return props.title.substring(0, colonIndex)
+})
+
+const subtitle = computed(() => {
+  const colonIndex = props.title.indexOf(':')
+  if (colonIndex === -1) return null
+  return props.title.substring(colonIndex + 1).trim()
+})
+</script>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -9,6 +9,7 @@ import BlogCard from './components/BlogCard.vue'
 import CustomButton from './components/CustomButton.vue'
 import DisclaimerBox from './components/DisclaimerBox.vue'
 import GradientCTA from './components/GradientCTA.vue'
+import BlogHeading from './components/BlogHeading.vue'
 
 export default {
   extends: DefaultTheme,
@@ -19,6 +20,7 @@ export default {
     app.component('CustomButton', CustomButton)
     app.component('DisclaimerBox', DisclaimerBox)
     app.component('GradientCTA', GradientCTA)
+    app.component('BlogHeading', BlogHeading)
   },
   Layout: () => {
     return h(DefaultTheme.Layout, null, {

--- a/docs/blog/from-problem-solver-to-systems-builder.md
+++ b/docs/blog/from-problem-solver-to-systems-builder.md
@@ -1,8 +1,8 @@
-# From Problem-Solver to Systems Builder: My Claude Code Transformation
-
-**Published**: September 2024
-**Author**: Benny (BANCS)
-**Reading Time**: 7 minutes
+<BlogHeading
+  title="From Problem-Solver to Systems Builder: My Claude Code Transformation"
+  publishDate="September 2024"
+  readingTime="7 minutes"
+/>
 
 ---
 

--- a/docs/blog/pause-not-procrastination.md
+++ b/docs/blog/pause-not-procrastination.md
@@ -1,8 +1,8 @@
-# The Pause Isn't Procrastination - It's Part of Your Process
-
-**Published**: October 26, 2025
-**Author**: Benny (BANCS)
-**Reading Time**: 12 minutes
+<BlogHeading
+  title="The Pause Isn't Procrastination - It's Part of Your Process"
+  publishDate="October 26, 2025"
+  readingTime="12 minutes"
+/>
 
 ---
 

--- a/docs/blog/working-with-claude.md
+++ b/docs/blog/working-with-claude.md
@@ -1,8 +1,8 @@
-# Working with Claude: An AI Pair Programming Experience
-
-**Published**: October 21, 2025
-**Author**: Benny (BANCS)
-**Reading Time**: 10 minutes
+<BlogHeading
+  title="Working with Claude: An AI Pair Programming Experience"
+  publishDate="October 21, 2025"
+  readingTime="10 minutes"
+/>
 
 <picture>
   <source


### PR DESCRIPTION
## Summary

- Create BlogHeading.vue component with responsive title splitting at colons
- Mobile (<768px): subtitle breaks to new line for better readability
- Desktop (≥768px): title and subtitle display on same line
- Default author to "Benny (Bancs AS)" for cleaner blog post code
- Update all blog posts to use new BlogHeading component
- Use pure Tailwind CSS utility classes (no custom CSS)

## Problem Solved

Blog titles with colons (like "Working with Claude: An AI Pair Programming Experience") wrapped awkwardly on mobile devices, making them hard to read.

## Solution

The `BlogHeading` component automatically detects colons in titles and breaks the subtitle to a new line on mobile while keeping it inline on desktop for optimal readability across all devices.

## Changes

- **New Component**: `docs/.vitepress/theme/components/BlogHeading.vue`
- **Theme Registration**: `docs/.vitepress/theme/index.ts`
- **Updated Blog Posts**: All 3 blog posts now use the component

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)