### PR TITLE
chore: enhance /cleanup to handle orphaned worktrees automatically

### DIFF
--- a/.claude/commands-templates/cleanup.md
+++ b/.claude/commands-templates/cleanup.md
@@ -18,33 +18,79 @@ Help me clean up a worktree after its feature branch has been merged.
    - Run: `git worktree list`
    - Identify the worktree path to remove
 
-4. **Remove the Worktree**
-   - Command: `git worktree remove worktrees/{worktree-name}`
-   - Example: `git worktree remove worktrees/feature-67-templates`
+4. **Prune Stale Worktree References**
+   - ALWAYS run first: `git worktree prune -v`
+   - This cleans up references to deleted worktrees
+   - Prepares for both normal and orphaned worktree removal
 
-5. **Delete Local Branch**
+5. **Detect and Remove Worktree**
+   - Check if worktree is tracked: `git worktree list | grep "worktrees/{worktree-name}"`
+   - **If tracked (normal case):**
+     - Try: `git worktree remove worktrees/{worktree-name}`
+     - If fails, try: `git worktree remove --force worktrees/{worktree-name}`
+     - Inform user: "Removed tracked worktree using git worktree remove"
+   - **If orphaned (not in git worktree list):**
+     - Check if directory exists: `ls worktrees/{worktree-name}`
+     - If exists, use: `rm -rf worktrees/{worktree-name}`
+     - Inform user: "Detected orphaned worktree, removed manually with rm -rf"
+
+6. **Delete Local Branch**
    - Command: `git branch -d {branch-name}`
    - Example: `git branch -d feature/67_templates`
    - If branch not fully merged, warn user before using `-D`
 
-6. **Update Issue Label**
+7. **Update Issue Label**
    - Run: `gh issue edit {issue-number} --remove-label "status: in progress"`
    - Run: `gh issue edit {issue-number} --add-label "status: done"`
 
-7. **Verify Cleanup**
+8. **Verify Cleanup**
    - Run: `git worktree list` to confirm removal
+   - Run: `ls -la worktrees/` to verify directory is gone
    - Run: `git branch` to confirm branch deletion
 
-## Example Flow
+## Example Flow (Normal Case)
 
 ```bash
 # From main repository
-gh pr view 67  # Verify merged
+gh pr view 67                              # Verify merged
+git worktree prune -v                      # Clean stale references first
 git worktree remove worktrees/feature-67-templates
 git branch -d feature/67_templates
 gh issue edit 67 --remove-label "status: in progress"
 gh issue edit 67 --add-label "status: done"
+git worktree list                          # Verify removal
+ls -la worktrees/                          # Verify directory gone
 ```
+
+## Example Flow (Orphaned Worktree)
+
+```bash
+# From main repository
+gh pr view 67                              # Verify merged
+git worktree prune -v                      # Clean stale references first
+git worktree list                          # Check if worktree is tracked
+# If not in list, it's orphaned
+ls worktrees/feature-67-templates          # Verify directory exists
+rm -rf worktrees/feature-67-templates      # Manual removal
+git branch -d feature/67_templates
+gh issue edit 67 --remove-label "status: in progress"
+gh issue edit 67 --add-label "status: done"
+```
+
+## Understanding Orphaned Worktrees
+
+A worktree becomes "orphaned" when:
+- The directory was manually deleted (e.g., `rm -rf worktrees/{name}`)
+- Git still has a reference to it in `.git/worktrees/`
+- `git worktree list` no longer shows it OR shows invalid path
+
+**Detection:**
+- Directory missing from `worktrees/` but git remembers it
+- OR directory exists but not in `git worktree list` output
+
+**Solution:**
+- Always run `git worktree prune` first to clean stale references
+- Then use manual removal (`rm -rf`) if needed
 
 ## Safety Checks
 
@@ -52,12 +98,14 @@ gh issue edit 67 --add-label "status: done"
 - ⚠️ Verify you're in the main repository before removal
 - ⚠️ Use `-d` (not `-D`) to safely delete branches
 - ⚠️ Keep worktree if you need to reference the code later
+- ⚠️ Always run `git worktree prune` before removal
 
 ## What Gets Cleaned Up
 
 - ✅ Worktree directory removed from `worktrees/`
 - ✅ Local feature branch deleted
 - ✅ Issue status updated to "done"
+- ✅ Stale worktree references pruned
 
 ## What Stays
 


### PR DESCRIPTION
## Summary

Enhanced the `/cleanup` slash command to automatically detect and handle orphaned worktrees, eliminating the need for manual intervention when worktrees are improperly deleted or git loses track of them.

## Changes

- **Automatic pruning**: Always run `git worktree prune -v` before removal attempts
- **Orphaned worktree detection**: Check if worktree is tracked in `git worktree list`
- **Graceful fallback handling**:
  - Tracked worktrees: `git worktree remove` → `git worktree remove --force`
  - Orphaned worktrees: `rm -rf` after verification
- **Enhanced verification**: Added `ls -la worktrees/` to physically verify removal
- **Improved documentation**:
  - New "Understanding Orphaned Worktrees" section
  - New "Example Flow (Orphaned Worktree)" with step-by-step guide
  - Enhanced troubleshooting tips

## Test Plan

- [x] Verify template file changes are correct
- [x] Confirm both installed command and template are updated
- [x] Validate commit message follows repo conventions
- [x] Check all acceptance criteria from issue #91 are met

## Files Changed

- `.claude/commands-templates/cleanup.md` - Template for future installations
- `.claude/commands/cleanup.md` - Installed command (not tracked in git)

## Benefits

- ✅ Handles both normal and orphaned worktrees automatically
- ✅ No manual intervention needed for edge cases
- ✅ More robust and user-friendly
- ✅ Prevents confusion when cleanup fails
- ✅ Follows best practices (prune before cleanup)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)