### PR TITLE
fix: remove invalid frame-ancestors directive from CSP meta tag

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
     // Note: X-Frame-Options removed - it has no effect when set via meta tag (must be HTTP header)
     ['meta', {
       'http-equiv': 'Content-Security-Policy',
-      content: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'none';"
+      content: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self';"
     }],
     ['meta', { 'http-equiv': 'X-Content-Type-Options', content: 'nosniff' }],
     ['meta', { 'http-equiv': 'Referrer-Policy', content: 'strict-origin-when-cross-origin' }],


### PR DESCRIPTION
## Summary
- Removed `frame-ancestors 'none'` from CSP meta tag in VitePress config
- This directive is invalid in HTML meta elements per CSP specification
- Only works in HTTP headers (not supported by GitHub Pages)

## Changes
- Updated `docs/.vitepress/config.ts` to remove the invalid directive

## Testing
- Verified CSP meta tag no longer contains `frame-ancestors`
- Other CSP directives remain intact

Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)