### PR TITLE
Fix: Forward slots in LayoutWithMain to display custom 404 page

### DIFF
--- a/docs/.vitepress/theme/LayoutWithMain.vue
+++ b/docs/.vitepress/theme/LayoutWithMain.vue
@@ -12,5 +12,12 @@ onMounted(() => {
 </script>
 
 <template>
-  <DefaultTheme.Layout />
+  <DefaultTheme.Layout>
+    <template #not-found>
+      <slot name="not-found" />
+    </template>
+    <template #layout-bottom>
+      <slot name="layout-bottom" />
+    </template>
+  </DefaultTheme.Layout>
 </template>


### PR DESCRIPTION
## Summary

Fixes the custom 404 page not displaying by adding slot forwarding in `LayoutWithMain.vue`.

## Changes

- Added slot forwarding for `not-found` slot to display custom 404 page (NotFound.vue)
- Added slot forwarding for `layout-bottom` slot to display footer component
- Ensures slots defined in `theme/index.ts` are properly passed through to `DefaultTheme.Layout`

## Root Cause

The `LayoutWithMain.vue` component was rendering `<DefaultTheme.Layout />` without forwarding any slots. The slots defined in `theme/index.ts` (`not-found` and `layout-bottom`) were being lost.

## Testing

- [x] Verified custom 404 page displays correctly when visiting non-existent URLs
- [x] Verified footer still displays correctly
- [x] Verified custom logo still displays correctly (uses Vite alias, not affected by this change)

## Impact

- Low risk - only adds slot forwarding, doesn't remove or modify existing functionality
- Fixes user experience on 404 pages
- Ensures custom branding displays on error pages

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)