### PR TITLE
Add dynamic preconnect to origin domain from CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.bancs.no

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,6 +10,11 @@ const packageJson = JSON.parse(
   readFileSync(join(__dirname, '../../package.json'), 'utf-8')
 )
 
+// Read CNAME file for dynamic origin domain preconnect
+const cnamePath = join(__dirname, '../public/CNAME')
+const cnameContent = readFileSync(cnamePath, 'utf-8').trim()
+const originDomain = `https://${cnameContent}`
+
 export default defineConfig({
   title: 'BANCS AS',
   description: 'Professional software development and consulting',
@@ -25,6 +30,8 @@ export default defineConfig({
   head: [
     ['link', { rel: 'icon', type: 'image/webp', href: '/bancs.webp' }],
     ['link', { rel: 'alternate icon', type: 'image/png', href: '/bancs.png' }],
+    // Preconnect to origin domain for faster resource loading
+    ['link', { rel: 'preconnect', href: originDomain }],
     // Security headers (meta tag fallback - GitHub Pages doesn't support custom HTTP headers)
     // Note: X-Frame-Options removed - it has no effect when set via meta tag (must be HTTP header)
     ['meta', {


### PR DESCRIPTION
## Summary

Adds a preconnect link to the origin domain (www.bancs.no) by dynamically reading from the CNAME file. This improves performance by establishing early connections to the origin server.

### Changes

- **Added dynamic CNAME reading** in VitePress config using `readFileSync`
- **Added preconnect link** early in head section for optimal performance  
- **Removed redundant CNAME file** from repo root (VitePress uses `docs/public/CNAME`)

### Benefits

- ✅ Faster resource loading through early connection establishment
- ✅ Better PageSpeed Insights score
- ✅ DRY principle - single source of truth for domain
- ✅ No hardcoded values

### Testing

- ✅ Build completes successfully without errors
- ✅ Preconnect link verified in generated HTML (`<link rel="preconnect" href="https://www.bancs.no">`)
- ✅ Site functions normally in dev and production builds

Resolves #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)