### PR TITLE
Add sitemap.xml for SEO

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
   title: 'BANCS AS',
   description: 'Professional software development and consulting',
   base: '/',
+  sitemap: {
+    hostname: 'https://www.bancs.no'
+  },
   ignoreDeadLinks: [
     // Example READMEs reference files outside docs/ (LICENSE, CONTRIBUTING.md, etc.)
     // These are meant for developers viewing in the repo, not the built site

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -5,5 +5,5 @@
 User-agent: *
 Allow: /
 
-# Sitemap location (for future implementation)
-# Sitemap: https://www.bancs.no/sitemap.xml
+# Sitemap location
+Sitemap: https://www.bancs.no/sitemap.xml


### PR DESCRIPTION
## Summary

Implements automatic XML sitemap generation to improve SEO and help search engines discover and index site content.

- Adds VitePress sitemap configuration with site hostname
- Activates sitemap reference in robots.txt
- Sitemap automatically regenerates on each build

## Changes

- `docs/.vitepress/config.ts`: Add sitemap configuration
- `docs/public/robots.txt`: Uncomment sitemap reference

## Testing

✅ Build successful - sitemap generates automatically  
✅ Sitemap includes all 18 site pages  
✅ Sitemap follows XML sitemap protocol  
✅ Accessible at `/sitemap.xml` after deployment

## Related Issues

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)