### PR TITLE
Add image attribution system with reusable component

### DIFF
--- a/docs/.vitepress/theme/components/HeroImage.vue
+++ b/docs/.vitepress/theme/components/HeroImage.vue
@@ -28,7 +28,7 @@ const gradientClasses = computed(() => {
 })
 
 const containerClasses = computed(() => [
-  'w-full h-64 md:h-80 rounded-lg mb-8 overflow-hidden',
+  'w-full h-64 md:h-80 rounded-lg overflow-hidden',
   {
     'blur-md': props.blurred
   }
@@ -43,24 +43,31 @@ const imageClasses = computed(() => [
 </script>
 
 <template>
-  <div :class="containerClasses">
-    <!-- Real image if src provided -->
-    <img
-      v-if="src"
-      :src="src"
-      :alt="alt"
-      :class="imageClasses"
-      loading="lazy"
-    />
+  <div class="mb-8">
+    <div :class="containerClasses">
+      <!-- Real image if src provided -->
+      <img
+        v-if="src"
+        :src="src"
+        :alt="alt"
+        :class="imageClasses"
+        loading="lazy"
+      />
 
-    <!-- Gradient placeholder if no src -->
-    <div
-      v-else
-      :class="[gradientClasses, 'w-full h-full flex items-center justify-center']"
-    >
-      <div class="text-center text-white/50 font-mono text-sm px-4">
-        {{ alt }}
+      <!-- Gradient placeholder if no src -->
+      <div
+        v-else
+        :class="[gradientClasses, 'w-full h-full flex items-center justify-center']"
+      >
+        <div class="text-center text-white/50 font-mono text-sm px-4">
+          {{ alt }}
+        </div>
       </div>
+    </div>
+
+    <!-- Attribution slot -->
+    <div v-if="$slots.default" class="text-xs text-gray-500 dark:text-gray-400 italic mt-2 text-center">
+      <slot />
     </div>
   </div>
 </template>

--- a/docs/.vitepress/theme/components/ImageAttribution.vue
+++ b/docs/.vitepress/theme/components/ImageAttribution.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+interface Props {
+  author: string
+  authorUrl?: string
+  source?: string
+  sourceUrl?: string
+  license?: string
+  licenseUrl?: string
+  modifications?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <span>
+    Photo by
+    <a v-if="authorUrl" :href="authorUrl" target="_blank" rel="noopener">{{ author }}</a>
+    <span v-else>{{ author }}</span>
+    <template v-if="source || sourceUrl">
+      on
+      <a v-if="sourceUrl" :href="sourceUrl" target="_blank" rel="noopener">{{ source || 'source' }}</a>
+      <span v-else>{{ source }}</span>
+    </template>
+    <template v-if="license">
+      <template v-if="licenseUrl">
+        , <a :href="licenseUrl" target="_blank" rel="noopener">{{ license }}</a>
+      </template>
+      <template v-else>
+        , {{ license }}
+      </template>
+    </template>
+    <template v-if="modifications">
+      , {{ modifications }}
+    </template>
+  </span>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -16,6 +16,7 @@ import PostPreview from './components/PostPreview.vue'
 import RevealStamp from './components/RevealStamp.vue'
 import SeriesNav from './components/SeriesNav.vue'
 import HeroImage from './components/HeroImage.vue'
+import ImageAttribution from './components/ImageAttribution.vue'
 
 export default {
   extends: DefaultTheme,
@@ -38,5 +39,6 @@ export default {
     app.component('RevealStamp', RevealStamp)
     app.component('SeriesNav', SeriesNav)
     app.component('HeroImage', HeroImage)
+    app.component('ImageAttribution', ImageAttribution)
   }
 } satisfies Theme

--- a/docs/blog/claude-code-collective.md
+++ b/docs/blog/claude-code-collective.md
@@ -11,7 +11,14 @@
   src="/images/blog/chronicles/the borg collective.jpg"
   alt="The Borg Collective - distributed AI consciousness"
   blurred
-/>
+>
+  <ImageAttribution
+    author="Basile Morin"
+    authorUrl="https://commons.wikimedia.org/w/index.php?curid=68889807"
+    license="CC BY-SA 4.0"
+    licenseUrl="https://creativecommons.org/licenses/by-sa/4.0/"
+  />
+</HeroImage>
 
 <PostPreview blurred>
   <template #stamp>

--- a/docs/blog/claude-code-stalactite.md
+++ b/docs/blog/claude-code-stalactite.md
@@ -17,7 +17,14 @@ date: 2025-11-04
   src="/images/blog/chronicles/pexels-paulseling-12275644.jpg"
   alt="Crystal formations representing persistent knowledge accumulation"
   blurred
-/>
+>
+  <ImageAttribution
+    author="Paul Seling"
+    authorUrl="https://www.pexels.com/@paulseling/"
+    source="Pexels"
+    sourceUrl="https://www.pexels.com/"
+  />
+</HeroImage>
 
 <PostPreview blurred>
   <template #stamp>


### PR DESCRIPTION
## Summary

Implements a complete image attribution system for blog posts with two components:

1. **HeroImage slot support** - Accepts attribution content via default slot
2. **ImageAttribution component** - Reusable component for structured credits

## Changes

- Added default slot to `HeroImage.vue` with styled attribution container
- Created `ImageAttribution.vue` component with props for author, source, license, modifications
- Registered component globally in theme config
- Applied attributions to Chronicles Post 1 (Pexels) and Post 3 (Wikimedia Commons)

## Benefits

✅ Standardized image credits across all blog posts  
✅ Flexible: supports both simple slot content and structured component  
✅ Encapsulation: image and attribution stay together as one unit  
✅ Proper link security attributes (`target="_blank" rel="noopener"`)

## Testing

- Tested with Pexels attribution (author + source)
- Tested with Wikimedia Commons attribution (author + license)
- Optional `licenseUrl` parameter supported

Closes #145

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)