### PR TITLE
docs: clarify purpose of root examples folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,22 @@
+# Public Code Examples
+
+Public code examples referenced in blog posts. Unlike `docs-internal/examples/` (internal development examples), these are meant for readers to learn from.
+
+## Current Examples
+
+### `working-with-claude/`
+
+VitePress configuration and blog parsing examples.
+
+Referenced by: [`docs/blog/working-with-claude.md`](../docs/blog/working-with-claude.md)
+
+## Adding New Examples
+
+1. Create directory: `examples/your-example-name/`
+2. Add well-commented code
+3. Include README with setup instructions
+4. Reference in your blog post
+
+---
+
+**Note:** This folder exists at root (not `docs-internal/`) for public accessibility.


### PR DESCRIPTION
## Summary

Adds documentation to clarify why `examples/` exists at the project root instead of in `docs-internal/`.

## Background

Initially investigated moving `examples/` to `docs-internal/examples/` for consistency. However, analysis revealed the root location is intentional:

- `examples/working-with-claude/` is referenced in public blog post `docs/blog/working-with-claude.md` (4 locations)
- Public examples need to be accessible to blog readers
- Different purpose than `docs-internal/examples/` (public vs internal)

## Changes

Added `examples/README.md` documenting:
- Purpose of root examples folder (public code examples)
- Distinction from `docs-internal/examples/`
- Current examples and their blog post references
- Guidelines for adding new public examples

Closes #158

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)