### PR TITLE
feat: add metadata to Chronicles landing page

### DIFF
--- a/docs/blog/claude-code-chronicles.md
+++ b/docs/blog/claude-code-chronicles.md
@@ -4,6 +4,14 @@ description: A three-part series revealing the power of distributed AI developme
 date: 2025-11-02
 ---
 
+<BlogHeading
+  title="The Claude Code Chronicles - Chapter 1"
+  publishDate="November 2, 2025"
+  readingTime="4 minutes"
+/>
+
+---
+
 <HeroImage
   src="/images/blog/chronicles/landing-hero-reveal.jpg"
   alt="Progressive reveal - symbolizing the staggered content disclosure of the Chronicles series"
@@ -12,15 +20,11 @@ date: 2025-11-02
     author="Daria Nekipelova"
     authorUrl="https://www.pexels.com/@daria-nekipelova-112078039/"
     source="Pexels"
-    sourceUrl="https://www.pexels.com/"
+    sourceUrl="https://www.pexels.com/photo/human-hand-from-behind-curtain-in-theatre-9665491/"
   />
 </HeroImage>
 
-# The Claude Code Chronicles - Chapter 1
-
 **When one AI becomes many, and GitHub Issues become persistent memory**
-
----
 
 ## The Discovery
 


### PR DESCRIPTION
## Summary

Add BlogHeading component with publication date and reading time to the Chronicles landing page. Fix page structure and attribution link to match series pattern.

**Changes:**
- Add BlogHeading with metadata (Nov 2, 2025, 4 min reading time)
- Fix structure: BlogHeading → HeroImage (matches series pattern)
- Remove duplicate H1 heading
- Remove redundant hr before first H2
- Fix Pexels attribution URL to specific photo

**Related:**
- Created #161 for series-wide hr/H2 consistency review

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)