### PR TITLE
feat: add DisclaimerBox and attribution to Chronicles posts

### DIFF
--- a/docs/blog/claude-code-chronicles.md
+++ b/docs/blog/claude-code-chronicles.md
@@ -15,6 +15,8 @@ hero:
 
 <BlogHeading />
 
+<DisclaimerBox type="claude" />
+
 **When one AI becomes many, and GitHub Issues become persistent memory**
 
 ## The Discovery
@@ -161,6 +163,10 @@ All posts are bookmarkable now. Content reveals progressively.
 - Check out [our existing blog posts](/blog/) on AI development
 - Explore the [BANCS project](/) to see this system in action
 - Read the [open-source documentation](https://github.com/BANCS-Norway/home) that makes it work
+
+---
+
+**Attribution**: This blog post was co-written with [Claude](https://claude.ai) (Chat for ideation and outline, Code for assembly and refinement). The experiences, insights, and creative direction are human; the execution and polish are collaborative.
 
 ---
 

--- a/docs/blog/claude-code-collective.md
+++ b/docs/blog/claude-code-collective.md
@@ -16,6 +16,8 @@ hero:
 
 <BlogHeading />
 
+<DisclaimerBox type="claude" />
+
 <PostPreview blurred>
   <template #stamp>
     <RevealStamp date="Tuesday, November 25th" />
@@ -93,6 +95,10 @@ Eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dic
 📅 **Publishing Date:** Tuesday, November 25th, 2025
 
 🔙 [Back to Series Overview](/blog/claude-code-chronicles)
+
+---
+
+**Attribution**: This blog post was co-written with [Claude](https://claude.ai) (Chat for ideation and outline, Code for assembly and refinement). The experiences, insights, and creative direction are human; the execution and polish are collaborative.
 
 </PostPreview>
 

--- a/docs/blog/claude-code-stalactite.md
+++ b/docs/blog/claude-code-stalactite.md
@@ -16,6 +16,8 @@ hero:
 
 <BlogHeading />
 
+<DisclaimerBox type="claude" />
+
 <PostPreview blurred>
   <template #stamp>
     <RevealStamp date="Tuesday, November 4th" />
@@ -70,6 +72,10 @@ Nisi ut aliquid ex ea commodi consequatur quis autem vel eum iure reprehenderit 
 📅 **Publishing Date:** Tuesday, November 4th, 2025
 
 🔙 [Back to Series Overview](/blog/claude-code-chronicles)
+
+---
+
+**Attribution**: This blog post was co-written with [Claude](https://claude.ai) (Chat for ideation and outline, Code for assembly and refinement). The experiences, insights, and creative direction are human; the execution and polish are collaborative.
 
 </PostPreview>
 

--- a/docs/blog/claude-code-workflow.md
+++ b/docs/blog/claude-code-workflow.md
@@ -11,6 +11,8 @@ hero:
 
 <BlogHeading />
 
+<DisclaimerBox type="claude" />
+
 <PostPreview blurred>
   <template #stamp>
     <RevealStamp date="Tuesday, November 11th" />
@@ -135,6 +137,10 @@ That shift in perspective is the difference between code that works today and sy
 📅 **Publishing Date:** Tuesday, November 11th, 2025
 
 🔙 [Back to Series Overview](/blog/claude-code-chronicles)
+
+---
+
+**Attribution**: This blog post was co-written with [Claude](https://claude.ai) (Chat for ideation and outline, Code for assembly and refinement). The experiences, insights, and creative direction are human; the execution and polish are collaborative.
 
 </PostPreview>
 


### PR DESCRIPTION
## Summary

Add AI collaboration disclosure to all four Claude Code Chronicles posts:
- Added `<DisclaimerBox type="claude" />` after BlogHeading
- Added end attribution crediting Claude collaboration
- Consistent placement matching the pause blog standard

## Files Changed

- `docs/blog/claude-code-chronicles.md` (landing page)
- `docs/blog/claude-code-stalactite.md` (Part 1)
- `docs/blog/claude-code-workflow.md` (Part 2)
- `docs/blog/claude-code-collective.md` (Part 3)

## Test Plan

- [x] DisclaimerBox renders correctly on all 4 posts
- [x] Attribution appears at end of each post
- [x] Placement is consistent across all posts
- [x] Matches styling of pause blog post
- [x] Tested in dev server

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)