### PR TITLE
Fix missing bottom border on presentation table

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -412,3 +412,7 @@ img[loading="lazy"] {
 .reveal .slide-table tbody tr:nth-child(even) {
   background-color: #f9f9f9;
 }
+
+.reveal .slide-table tbody tr:last-child td {
+  border-bottom: 2px solid #ddd;
+}


### PR DESCRIPTION
## Summary
Fixes the missing bottom border on the last row of the Before & After comparison table in slide 9 of the Enonic meetup presentation.

## Changes
- Added explicit CSS rule for `.slide-table tbody tr:last-child td` to ensure bottom border renders correctly

## Test Plan
- [x] Started dev server and verified table border appears correctly
- [x] Visual confirmation on slide 9 of the presentation

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)