### PR TITLE
fix: add Enonic XP version number to React4XP migration blog post

### DIFF
--- a/docs/blog/enonic-meetup-react4xp-migration.md
+++ b/docs/blog/enonic-meetup-react4xp-migration.md
@@ -203,7 +203,7 @@ On December 4, 2025, I presented at the [Enonic Oslo Meetup](https://www.meetup.
 
 ## The Forced Upgrade
 
-In early October 2025, [Liberalistene.no](https://liberalistene.no) was running smoothly on Enonic Cloud with React4XP v3. Then came the notification: Enonic needed to upgrade XP to the latest version, and **React4XP v3 was blocking the upgrade**.
+In early October 2025, [Liberalistene.no](https://liberalistene.no) was running smoothly on Enonic Cloud with React4XP v3. Then came the notification: Enonic needed to upgrade Enonic XP to version 7.15, and **React4XP v3 was blocking the upgrade**.
 
 We had no choice. We had to migrate to React4XP v6 as fast as possible.
 


### PR DESCRIPTION
## Summary

- Adds Enonic XP version 7.15 to the blog post to provide historical context and technical accuracy

## Changes

- Updated "The Forced Upgrade" section to specify "Enonic XP to version 7.15" instead of just "XP to the latest version"

## Why This Matters

- **Historical accuracy** - Documents the specific version being upgraded to
- **Technical context** - Helps readers understand version-specific considerations
- **Future reference** - Useful when comparing approaches across different Enonic XP versions

## Test Plan

- [x] Read the blog post to verify the addition makes sense in context
- [x] Verify it's in the right location (The Forced Upgrade section)
- [ ] Preview the deployed site to ensure rendering is correct

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)