### PR TITLE
style: fix inline code readability in dark mode and auto-discover blog posts in a11y tests

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -116,7 +116,7 @@ export default defineConfig({
 
   markdown: {
     theme: {
-      light: 'github-light',
+      light: 'github-light-high-contrast',
       dark: 'github-dark'
     },
     lineNumbers: true

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -42,6 +42,12 @@ div[class*='language-'] {
   background-color: var(--vp-c-bg-alt) !important;
 }
 
+/* Inline code - dark mode contrast fix */
+.dark :not(pre) > code {
+  background-color: rgba(255, 255, 255, 0.12);
+  color: #e2e8f0;
+}
+
 /* Logo styling */
 .VPNavBarTitle .logo {
   transition: transform 300ms;

--- a/tests/accessibility.test.ts
+++ b/tests/accessibility.test.ts
@@ -3,23 +3,44 @@
  *
  * Tests all VitePress pages for WCAG 2.1 Level AA compliance.
  * The preview server is automatically managed by playwright.config.ts
+ *
+ * Blog posts are discovered automatically from docs/blog/ — no manual
+ * updates needed when new posts are added.
  */
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { readdirSync } from 'fs';
+import { join, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 interface TestPage {
   path: string;
   name: string;
 }
 
-// Pages to test for accessibility
-const pagesToTest: TestPage[] = [
+// Discover all blog posts automatically from the blog directory
+function getBlogPostPages(): TestPage[] {
+  const blogDir = join(__dirname, '..', 'docs', 'blog');
+  return readdirSync(blogDir)
+    .filter(file => file.endsWith('.md') && file !== 'index.md')
+    .map(file => {
+      const slug = basename(file, '.md');
+      return { path: `/blog/${slug}`, name: `Blog: ${slug}` };
+    });
+}
+
+// Static pages to test
+const staticPages: TestPage[] = [
   { path: '/', name: 'Home' },
-  { path: '/blog/', name: 'Blog' },
+  { path: '/blog/', name: 'Blog index' },
   { path: '/projects', name: 'Projects' },
   { path: '/contact', name: 'Contact' },
   { path: '/about', name: 'About' },
 ];
+
+const pagesToTest: TestPage[] = [...staticPages, ...getBlogPostPages()];
 
 // Create a test for each page
 for (const pageInfo of pagesToTest) {


### PR DESCRIPTION
## Summary

- Fix inline `<code>` contrast in dark mode — adds `rgba(255,255,255,0.12)` background and `#e2e8f0` text colour in `custom.css`
- Switch Shiki light theme from `github-light` to `github-light-high-contrast` — fixes pre-existing WCAG AA contrast failures in code blocks across multiple blog posts
- Refactor accessibility tests to auto-discover blog posts from `docs/blog/` — new posts are tested automatically with no manual updates required

## Why the Shiki theme change?

The auto-discovery immediately caught pre-existing contrast failures (`#e36209` at 3.33:1 and `#d73a49` at 4.37:1 on `#f8fafc`) in three blog posts that CI had never tested. Switching to `github-light-high-contrast` resolves all of them.

## Test plan

- [x] All 15 accessibility tests passing locally (5 static pages + 10 blog posts)
- [ ] Verify code blocks look correct visually in light mode with the new Shiki theme
- [ ] Verify inline code is readable in dark mode

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)