### PR TITLE
feat: add UpcomingPosts widget to blog index

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     // Note: X-Frame-Options removed - it has no effect when set via meta tag (must be HTTP header)
     ['meta', {
       'http-equiv': 'Content-Security-Policy',
-      content: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self';"
+      content: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.github.com;"
     }],
     ['meta', { 'http-equiv': 'X-Content-Type-Options', content: 'nosniff' }],
     ['meta', { 'http-equiv': 'Referrer-Policy', content: 'strict-origin-when-cross-origin' }],

--- a/docs/.vitepress/theme/components/UpcomingPosts.vue
+++ b/docs/.vitepress/theme/components/UpcomingPosts.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface UpcomingPost {
+  number: number
+  title: string
+  estimated: string
+  tags: string[]
+}
+
+const posts = ref<UpcomingPost[]>([])
+const loading = ref(true)
+const error = ref(false)
+
+function parseField(body: string, fieldName: string): string {
+  const lines = body.split('\n')
+  const headerIndex = lines.findIndex(l => l.trim().toLowerCase().startsWith(`### ${fieldName.toLowerCase()}`))
+  if (headerIndex === -1) return ''
+  for (let i = headerIndex + 1; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (line.startsWith('###')) break
+    if (line && line !== '_No response_') return line
+  }
+  return ''
+}
+
+function parseTags(body: string): string[] {
+  const raw = parseField(body, 'Tags')
+  if (!raw) return []
+  return raw.split(',').map(t => t.trim()).filter(Boolean)
+}
+
+// Returns the last Date of the estimated period, or null if unparseable.
+// Formats: "2025-06" (year-month) or "2025-Q2" (quarter)
+function estimatedEndDate(estimated: string): Date | null {
+  const yearMonth = estimated.match(/^(\d{4})-(\d{2})$/)
+  if (yearMonth) {
+    const year = parseInt(yearMonth[1])
+    const month = parseInt(yearMonth[2]) // 1-based
+    // Last day of that month
+    return new Date(year, month, 0)
+  }
+  const quarter = estimated.match(/^(\d{4})-Q([1-4])$/)
+  if (quarter) {
+    const year = parseInt(quarter[1])
+    const endMonth = parseInt(quarter[2]) * 3 // Q1=3, Q2=6, Q3=9, Q4=12
+    return new Date(year, endMonth, 0)
+  }
+  return null
+}
+
+function isStale(estimated: string): boolean {
+  const end = estimatedEndDate(estimated)
+  if (!end) return false // unparseable — show it
+  return end < new Date()
+}
+
+onMounted(async () => {
+  try {
+    const res = await fetch(
+      'https://api.github.com/repos/BANCS-Norway/home/issues?labels=upcoming-post&state=open&per_page=20'
+    )
+    if (!res.ok) throw new Error('fetch failed')
+    const issues = await res.json()
+    posts.value = issues
+      .map((issue: { number: number; title: string; body: string }) => ({
+        number: issue.number,
+        title: issue.title,
+        estimated: parseField(issue.body ?? '', 'Estimated'),
+        tags: parseTags(issue.body ?? '')
+      }))
+      .filter((post: UpcomingPost) => !isStale(post.estimated))
+  } catch {
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <p v-if="loading" class="text-[var(--vp-c-text-2)] italic">Loading...</p>
+
+  <template v-else-if="!error">
+    <h2>Planned posts</h2>
+    <ul v-if="posts.length > 0" class="list-none p-0">
+      <li v-for="post in posts" :key="post.number" class="mb-4">
+        <a
+          :href="`/upcoming?issue=${post.number}`"
+          class="text-[var(--vp-c-brand-1)] hover:text-[var(--vp-c-brand-2)] font-medium no-underline"
+        >{{ post.title }}</a>
+        <span v-if="post.estimated" class="text-[var(--vp-c-text-2)] text-sm ml-2">— {{ post.estimated }}</span>
+        <div v-if="post.tags.length > 0" class="flex flex-wrap gap-1 mt-1">
+          <span
+            v-for="tag in post.tags"
+            :key="tag"
+            class="inline-block px-2 py-0.5 rounded text-xs font-medium bg-[var(--vp-c-brand-soft)] text-[var(--vp-c-brand-1)]"
+          >{{ tag }}</span>
+        </div>
+      </li>
+    </ul>
+
+    <p v-else class="text-[var(--vp-c-text-2)] italic">
+      Nothing planned yet — watch this space.
+    </p>
+  </template>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -20,6 +20,7 @@ import ImageAttribution from './components/ImageAttribution.vue'
 import BlogIndex from './components/BlogIndex.vue'
 import InfinityDivider from './components/InfinityDivider.vue'
 import RevealPresentation from './components/RevealPresentation.vue'
+import UpcomingPosts from './components/UpcomingPosts.vue'
 
 export default {
   extends: DefaultTheme,
@@ -46,5 +47,6 @@ export default {
     app.component('BlogIndex', BlogIndex)
     app.component('InfinityDivider', InfinityDivider)
     app.component('RevealPresentation', RevealPresentation)
+    app.component('UpcomingPosts', UpcomingPosts)
   }
 } satisfies Theme

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -6,20 +6,7 @@ Welcome to the BANCS blog, where we share insights about software development, A
 
 <BlogIndex />
 
-## Coming Soon
-
-<BlogCard>
-
-### Building a Modern Blog with VitePress
-**Date**: Coming Soon
-
-A comprehensive guide to setting up a professional blog using VitePress, TypeScript, and Tailwind CSS. Includes deployment to GitHub Pages and custom domain configuration.
-
-**Topics**: VitePress, TypeScript, Tailwind, GitHub Pages
-
-*Coming Soon*
-
-</BlogCard>
+<UpcomingPosts />
 
 ## Topics
 


### PR DESCRIPTION
## Summary

- New `UpcomingPosts.vue` component that fetches open GitHub Issues labelled `upcoming-post` from the public API
- Stale posts (estimated date in the past) are filtered out automatically — no manual cleanup needed
- Closed issues (published posts) are excluded by the API query (`state=open`)
- Parses `estimated` (supports `YYYY-MM` and `YYYY-Qn` formats) and `tags` from issue body markdown sections
- Renders as a plain linked list below Recent Posts, with estimated date inline and tag badges
- Loading, empty ("Nothing planned yet — watch this space.") and error (silent hide) states handled
- CSP updated to allow `connect-src api.github.com`
- Static hardcoded Coming Soon placeholder removed from `blog/index.md`

## Test plan

- [ ] Visit `/blog/` — "Planned posts" heading appears below Recent Posts
- [ ] Issue #206 (`2026-Q2`) is visible with tags
- [ ] Issue #207 (`2025-12`) is **not** visible (filtered as stale)
- [ ] Close issue #206 — it disappears from the widget automatically
- [ ] No API key or auth required

## Dependencies

- Depends on #202 (upcoming-post issue template) for real issues to exist in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)