### PR TITLE
chore(ci): fix issue-triage OIDC permission and allowed tools

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   issues: write
+  id-token: write
 
 jobs:
   triage:
@@ -21,7 +22,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: "Bash(gh:*)"
+          claude_args: "--allowedTools Bash(gh:*)"
           prompt: |
             You are an automated issue triage assistant for the BANCS Norway home repository.
             A GitHub issue event just fired. Here are the details:


### PR DESCRIPTION
## Summary

- Add missing `id-token: write` permission required for `claude_code_oauth_token` OIDC authentication
- Move tool restriction from invalid `allowed_tools` input to `claude_args: "--allowedTools Bash(gh:*)"`

## Root cause

`claude-code-action@v1` does not support `allowed_tools` as a direct input — it was silently ignored (warning only). The OIDC auth failure was the actual blocker, requiring `id-token: write` in workflow permissions.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)