### PR TITLE
chore(ci): add social-schedule workflow for automated Publer posting

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -1,0 +1,390 @@
+name: Schedule social posts
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  schedule-social:
+    name: Generate and schedule social posts
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find blog post
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          # Find .md files added/modified in docs/blog/ (excluding index.md)
+          # Pick the one with most additions — that's the new post, not index edits
+          BLOG_FILE=$(gh pr view "$PR_NUMBER" --json files \
+            --jq '.files[] | select(.path | test("^docs/blog/(?!index\\.md).+\\.md$")) | "\(.additions) \(.path)"' \
+            | sort -rn | head -1 | awk '{print $2}')
+
+          if [ -z "$BLOG_FILE" ]; then
+            echo "No blog post file found in this PR — skipping social scheduling."
+            echo "found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "found=true" >> $GITHUB_OUTPUT
+          echo "file=$BLOG_FILE" >> $GITHUB_OUTPUT
+
+          SLUG=$(basename "$BLOG_FILE" .md)
+          echo "slug=$SLUG" >> $GITHUB_OUTPUT
+          echo "url=https://www.bancs.no/blog/$SLUG" >> $GITHUB_OUTPUT
+          echo "Blog post found: $BLOG_FILE (slug: $SLUG)"
+
+      - name: Parse frontmatter
+        if: steps.find.outputs.found == 'true'
+        id: parse
+        env:
+          BLOG_FILE: ${{ steps.find.outputs.file }}
+        run: |
+          python3 << 'PYEOF'
+          import yaml, re, os, sys
+
+          blog_file = os.environ['BLOG_FILE']
+          github_output = os.environ['GITHUB_OUTPUT']
+
+          with open(blog_file, 'r') as f:
+              raw = f.read()
+
+          # Split on frontmatter delimiters
+          parts = raw.split('---\n', 2)
+          if len(parts) < 3:
+              print("ERROR: No frontmatter found", file=sys.stderr)
+              sys.exit(1)
+
+          fm = yaml.safe_load(parts[1])
+          content = parts[2]
+
+          # Basic fields
+          title = fm.get('title', '')
+          date = str(fm.get('socialDate') or fm.get('date', ''))  # socialDate takes precedence (#213)
+          subtitle = fm.get('subtitle', '')
+
+          # Skip if social date is in the past
+          import datetime
+          if date and datetime.date.fromisoformat(date) < datetime.date.today():
+              print(f'Social date {date} is in the past — skipping.')
+              with open(github_output, 'a') as out:
+                  out.write('found=false\n')
+              sys.exit(0)
+
+          # Hero fields
+          hero = fm.get('hero', {}) or {}
+          hero_attribution = (hero.get('attribution') or {}).get('author', '')
+          hero_instagram = hero.get('instagram', '')  # square crop for Instagram, min 1080x1080
+
+          # relatedArticles — future feature, parsed now so the field is supported
+          related = fm.get('relatedArticles', []) or []
+          related_links = '\n'.join(
+              f"* {a.get('title', '')}: https://www.bancs.no{a.get('url', '')}"
+              for a in related if a.get('title') and a.get('url')
+          )
+
+          # SeriesNav — parse prev/next from Vue component in content
+          prev_title = prev_url = next_title = next_url = ''
+          nav_match = re.search(r'<SeriesNav([^/]*)/>', content, re.DOTALL)
+          if nav_match:
+              nav_str = nav_match.group(1)
+              prev_m = re.search(r':prev="[^"]*text:\s*[\'"](.+?)[\'"][^"]*link:\s*[\'"](.+?)[\'"]', nav_str)
+              next_m = re.search(r':next="[^"]*text:\s*[\'"](.+?)[\'"][^"]*link:\s*[\'"](.+?)[\'"]', nav_str)
+              if prev_m:
+                  prev_title, prev_url = prev_m.group(1), 'https://www.bancs.no' + prev_m.group(2)
+              if next_m:
+                  next_title, next_url = next_m.group(1), 'https://www.bancs.no' + next_m.group(2)
+
+          # Clean content for Claude: strip Vue components and leading attribution lines
+          clean = re.sub(r'<[A-Z][^\n>]*/>', '', content)           # self-closing Vue components
+          clean = re.sub(r'<[A-Z][^>]*>.*?</[A-Z][^>]*>', '', clean, flags=re.DOTALL)  # block components
+          clean = clean.strip()
+
+          # Write outputs
+          with open(github_output, 'a') as out:
+              out.write(f"title={title}\n")
+              out.write(f"date={date}\n")
+              out.write(f"subtitle={subtitle}\n")
+              out.write(f"hero_attribution={hero_attribution}\n")
+              out.write(f"hero_instagram={hero_instagram}\n")
+              out.write(f"prev_title={prev_title}\n")
+              out.write(f"prev_url={prev_url}\n")
+              out.write(f"next_title={next_title}\n")
+              out.write(f"next_url={next_url}\n")
+              out.write(f"has_related={'true' if related_links else 'false'}\n")
+
+          with open('/tmp/post_content.md', 'w') as f:
+              f.write(clean)
+
+          with open('/tmp/related_links.txt', 'w') as f:
+              f.write(related_links)
+
+          print(f"Parsed: {title!r} ({date})")
+          PYEOF
+
+      - name: Generate social content via Claude
+        if: steps.find.outputs.found == 'true'
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are a social media copywriter for Benny Molowny Thomas, a Norwegian solo developer
+            and consultant at BANCS AS. He writes about Claude Code methodology, open source, and
+            software development. His tone is direct, technically credible, and occasionally dry.
+            He does not use hype language.
+
+            Blog post title: ${{ steps.parse.outputs.title }}
+            Publish date: ${{ steps.parse.outputs.date }}
+            Post URL: ${{ steps.find.outputs.url }}
+
+            Read the full blog post content from /tmp/post_content.md.
+
+            Generate social media content and write it as valid JSON to /tmp/claude-output.json
+            with exactly this structure — no markdown fences, no explanation, just the JSON:
+            {
+              "linkedin_body": "Post body mirroring H2 sections with condensed text and code blocks interleaved as in the original. Ends with: Read the complete article: <url>. No disclaimer or attribution — those are added separately.",
+              "twitter": "Max 260 chars. Punchy and direct. URL is appended separately — do not include it.",
+              "instagram": "150-300 chars. Conversational. 3-5 relevant hashtags at the end. No URL."
+            }
+
+      - name: Validate Claude output
+        if: steps.find.outputs.found == 'true'
+        run: |
+          if [ ! -f /tmp/claude-output.json ]; then
+            echo "Claude did not write /tmp/claude-output.json"
+            exit 1
+          fi
+
+          jq -e '.linkedin_body and .twitter and .instagram' /tmp/claude-output.json > /dev/null \
+            || { echo "Unexpected JSON structure in Claude output"; cat /tmp/claude-output.json; exit 1; }
+
+          echo "Claude output validated successfully"
+
+      - name: Assemble LinkedIn post
+        if: steps.find.outputs.found == 'true'
+        env:
+          POST_URL: ${{ steps.find.outputs.url }}
+          PREV_TITLE: ${{ steps.parse.outputs.prev_title }}
+          PREV_URL: ${{ steps.parse.outputs.prev_url }}
+          NEXT_TITLE: ${{ steps.parse.outputs.next_title }}
+          NEXT_URL: ${{ steps.parse.outputs.next_url }}
+          HAS_RELATED: ${{ steps.parse.outputs.has_related }}
+        run: |
+          python3 << 'PYEOF'
+          import os, json
+
+          DISCLAIMER = """> ℹ️ Disclaimer: I am not affiliated with, employed by, or sponsored by Anthropic. I am a paying Claude Pro subscriber and receive no compensation or endorsement for mentioning Claude in this article. All opinions and experiences shared are my own."""
+
+          ATTRIBUTION = """*Attribution: This blog post was co-written with Claude (Chat for ideation and outline, Code for assembly and refinement). The experiences, insights, and creative direction are human; the execution and polish are collaborative.*"""
+
+          with open('/tmp/claude-output.json') as f:
+              body = json.load(f)['linkedin_body'].strip()
+
+          prev_title = os.environ.get('PREV_TITLE', '')
+          prev_url   = os.environ.get('PREV_URL', '')
+          next_title = os.environ.get('NEXT_TITLE', '')
+          next_url   = os.environ.get('NEXT_URL', '')
+          has_related = os.environ.get('HAS_RELATED', 'false') == 'true'
+
+          parts = [DISCLAIMER, '---', body]
+
+          # Series links (from SeriesNav)
+          series_links = []
+          if prev_title and prev_url:
+              series_links.append(f"* {prev_title}: {prev_url}")
+          if next_title and next_url:
+              series_links.append(f"* {next_title}: {next_url}")
+          if series_links:
+              parts.append('Catch up on the series:\n\n' + '\n'.join(series_links))
+
+          # Related articles (from relatedArticles frontmatter)
+          if has_related:
+              with open('/tmp/related_links.txt') as f:
+                  related = f.read().strip()
+              if related:
+                  parts.append('Did you like this topic? Read more about it in these articles:\n\n' + related)
+
+          parts.extend(['---', ATTRIBUTION, '---'])
+
+          full_post = '\n\n'.join(parts)
+
+          with open('/tmp/linkedin_post.txt', 'w') as f:
+              f.write(full_post)
+
+          print(f"LinkedIn post assembled ({len(full_post)} chars)")
+          PYEOF
+
+      - name: Upload Instagram image to Publer
+        if: steps.find.outputs.found == 'true' && steps.parse.outputs.hero_instagram != ''
+        id: instagram_media
+        env:
+          PUBLER_API_KEY: ${{ secrets.PUBLER_API_KEY }}
+          PUBLER_WORKSPACE_ID: ${{ secrets.PUBLER_WORKSPACE_ID }}
+          HERO_INSTAGRAM: ${{ steps.parse.outputs.hero_instagram }}
+        run: |
+          # hero_instagram is a path like /images/blog/post-slug/hero-instagram.jpg
+          # Map to the file in the repo under docs/public/
+          IMAGE_FILE="docs/public${HERO_INSTAGRAM}"
+
+          if [ ! -f "$IMAGE_FILE" ]; then
+            echo "Instagram image not found at $IMAGE_FILE — skipping Instagram media upload"
+            echo "media_id=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          RESPONSE=$(curl -sf -X POST "https://app.publer.com/api/v1/media" \
+            -H "Authorization: Bearer-API $PUBLER_API_KEY" \
+            -H "Publer-Workspace-Id: $PUBLER_WORKSPACE_ID" \
+            -F "file=@$IMAGE_FILE") || { echo "Publer media upload failed"; echo "media_id=" >> $GITHUB_OUTPUT; exit 0; }
+
+          MEDIA_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+          if [ -z "$MEDIA_ID" ]; then
+            echo "Publer media upload returned no ID: $RESPONSE"
+            echo "media_id=" >> $GITHUB_OUTPUT
+          else
+            echo "Instagram image uploaded, media_id: $MEDIA_ID"
+            echo "media_id=$MEDIA_ID" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Schedule via Publer
+        if: steps.find.outputs.found == 'true'
+        id: publer
+        env:
+          PUBLER_API_KEY: ${{ secrets.PUBLER_API_KEY }}
+          PUBLER_WORKSPACE_ID: ${{ secrets.PUBLER_WORKSPACE_ID }}
+          PUBLER_LINKEDIN_ACCOUNT_ID: ${{ secrets.PUBLER_LINKEDIN_ACCOUNT_ID }}
+          PUBLER_TWITTER_ACCOUNT_ID: ${{ secrets.PUBLER_TWITTER_ACCOUNT_ID }}
+          PUBLER_INSTAGRAM_ACCOUNT_ID: ${{ secrets.PUBLER_INSTAGRAM_ACCOUNT_ID }}
+          POST_DATE: ${{ steps.parse.outputs.date }}
+          POST_URL: ${{ steps.find.outputs.url }}
+          INSTAGRAM_MEDIA_ID: ${{ steps.instagram_media.outputs.media_id }}
+        run: |
+          python3 << 'PYEOF'
+          import os, json, urllib.request, urllib.error
+
+          api_key      = os.environ['PUBLER_API_KEY']
+          workspace_id = os.environ['PUBLER_WORKSPACE_ID']
+          post_date    = os.environ['POST_DATE']
+          post_url     = os.environ['POST_URL']
+
+          # 09:00 Europe/Oslo — calculate UTC offset (CET=+01:00, CEST=+02:00)
+          import subprocess, datetime
+          tz_offset = subprocess.run(
+              ['date', '-d', f'{post_date} 09:00:00', '+%z'],
+              env={**os.environ, 'TZ': 'Europe/Oslo'}, capture_output=True, text=True
+          ).stdout.strip()
+          scheduled_at = f'{post_date}T09:00:00{tz_offset[:3]}:{tz_offset[3:]}'
+
+          with open('/tmp/linkedin_post.txt') as f:
+              linkedin_text = f.read()
+          twitter_text  = open('/tmp/claude-output.json').read()
+          twitter_text  = json.loads(twitter_text)['twitter'] + ' ' + post_url
+          instagram_text = json.loads(open('/tmp/claude-output.json').read())['instagram']
+          instagram_media_id = os.environ.get('INSTAGRAM_MEDIA_ID', '')
+
+          def schedule(account_id, text, platform, media_id=None):
+              post = {
+                  'accounts': [{'id': account_id, 'scheduled_at': scheduled_at}],
+                  'networks': {platform: {'text': text}}
+              }
+              if media_id:
+                  post['networks'][platform]['media'] = [{'id': media_id, 'type': 'image'}]
+
+              payload = json.dumps({'bulk': {'state': 'scheduled', 'posts': [post]}}).encode()
+              req = urllib.request.Request(
+                  'https://app.publer.com/api/v1/posts/schedule',
+                  data=payload,
+                  headers={
+                      'Authorization': f'Bearer-API {api_key}',
+                      'Publer-Workspace-Id': workspace_id,
+                      'Content-Type': 'application/json',
+                  }
+              )
+              try:
+                  with urllib.request.urlopen(req) as resp:
+                      result = json.loads(resp.read())
+                      print(f'{platform}: scheduled (job_id: {result.get("job_id", "?")})')
+                      return True
+              except urllib.error.HTTPError as e:
+                  print(f'{platform}: failed — {e.read().decode()}')
+                  return False
+
+          linkedin_ok  = schedule(os.environ['PUBLER_LINKEDIN_ACCOUNT_ID'],  linkedin_text,  'linkedin')
+          twitter_ok   = schedule(os.environ['PUBLER_TWITTER_ACCOUNT_ID'],   twitter_text,   'twitter')
+          instagram_ok = schedule(
+              os.environ['PUBLER_INSTAGRAM_ACCOUNT_ID'],
+              instagram_text,
+              'instagram',
+              media_id=instagram_media_id or None
+          )
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'linkedin_ok={"true" if linkedin_ok else "false"}\n')
+              f.write(f'twitter_ok={"true" if twitter_ok else "false"}\n')
+              f.write(f'instagram_ok={"true" if instagram_ok else "false"}\n')
+
+          if not linkedin_ok and not twitter_ok and not instagram_ok:
+              raise SystemExit('All Publer API calls failed')
+          PYEOF
+
+      - name: Post PR comment
+        if: steps.find.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          POST_TITLE: ${{ steps.parse.outputs.title }}
+          POST_DATE: ${{ steps.parse.outputs.date }}
+          LINKEDIN_OK: ${{ steps.publer.outputs.linkedin_ok }}
+          TWITTER_OK: ${{ steps.publer.outputs.twitter_ok }}
+          INSTAGRAM_OK: ${{ steps.publer.outputs.instagram_ok }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 << 'PYEOF'
+          import os, subprocess
+
+          date = os.environ['POST_DATE']
+          title = os.environ['POST_TITLE']
+
+          scheduled = subprocess.run(
+              ['date', '-d', f'{date} 09:00:00', '+%A %B %-d, %Y at 09:00 CET'],
+              env={**os.environ, 'TZ': 'Europe/Oslo'},
+              capture_output=True, text=True
+          ).stdout.strip()
+
+          def status(val):
+              return 'checked' if val == 'true' else 'x'
+
+          lines = [
+              f'## Scheduled for {scheduled}',
+              '',
+              f'**{title}**',
+              '',
+              '| Platform | Status |',
+              '|----------|--------|',
+              f'| LinkedIn | {status(os.environ["LINKEDIN_OK"])} |',
+              f'| Twitter/X | {status(os.environ["TWITTER_OK"])} |',
+              f'| Instagram | {status(os.environ["INSTAGRAM_OK"])} |',
+              '',
+              '_Generated by Claude Sonnet 4.6, queued in Buffer._',
+          ]
+
+          with open('/tmp/pr_comment.md', 'w') as f:
+              f.write('\n'.join(lines))
+          PYEOF
+
+          gh pr comment "$PR_NUMBER" --body-file /tmp/pr_comment.md


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/social-schedule.yml` — triggers on merged PRs to `main` containing `docs/blog/*.md` changes
- Generates LinkedIn, Twitter/X, and Instagram content via `claude-code-action` (uses existing `CLAUDE_CODE_OAUTH_TOKEN`)
- Schedules all three via Publer API at 09:00 Europe/Oslo on the post's social date
- LinkedIn post assembled with static disclaimer, series nav, related articles, and attribution
- Instagram uses a square hero crop (`hero.instagram` frontmatter field) uploaded via Publer media endpoint
- Prefers `socialDate` over `date` when present (#213)
- Skips silently if social date is in the past

## Secrets to add before this is live

| Secret | Description |
|--------|-------------|
| `PUBLER_API_KEY` | Publer API key (Settings → Access & Login → API Keys) |
| `PUBLER_WORKSPACE_ID` | Publer workspace ID |
| `PUBLER_LINKEDIN_ACCOUNT_ID` | Publer account ID for LinkedIn |
| `PUBLER_TWITTER_ACCOUNT_ID` | Publer account ID for Twitter/X |
| `PUBLER_INSTAGRAM_ACCOUNT_ID` | Publer account ID for Instagram |

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)