### PR TITLE
fix: update org number and VAT registration status for BANCS AS

### DIFF
--- a/docs/.vitepress/theme/components/Footer.vue
+++ b/docs/.vitepress/theme/components/Footer.vue
@@ -21,7 +21,7 @@ import { version } from '../../../../package.json'
         <a
           href="/about"
           class="text-(--vp-c-brand) underline hover:no-underline"
-        >BANCS AS</a> · Org.nr: 927 177 579 · Allegaten 6, 4400 Flekkefjord ·
+        >BANCS AS</a> · Org.nr: 927 177 579 MVA · Allegaten 6, 4400 Flekkefjord ·
         <a
           href="mailto:contact@bancs.no"
           class="text-(--vp-c-brand) underline hover:no-underline"

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -34,10 +34,10 @@ Norway
 
 ## Foretaksinformasjon (Company Information)
 
-**Organisasjonsnummer:** 927 177 579
-**Registrert adresse:** Allegaten 6, 4400 Flekkefjord
-**E-post:** contact@bancs.no
-**MVA-registrert:** Nei (terskel er 50 000 NOK)
+**Organisasjonsnummer:** 927 177 579\
+**Registrert adresse:** Allegaten 6, 4400 Flekkefjord\
+**E-post:** contact@bancs.no\
+**MVA-registrert:** Ja
 
 ## Response Time
 


### PR DESCRIPTION
## Summary

- Add `MVA` suffix to org number in footer (`Org.nr: 927 177 579 MVA`)
- Update contact page VAT registration status from `Nei` to `Ja`
- Fix missing hard line breaks in Foretaksinformasjon block (fields were rendering as one dense paragraph)

## Test plan

- [ ] Verify footer displays `Org.nr: 927 177 579 MVA`
- [ ] Verify contact page shows `MVA-registrert: Ja`
- [ ] Verify contact page company info fields each render on their own line

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)