### PR TITLE
chore(ci): fix Publer post types, scheduling logic, and Instagram crop

### DIFF
--- a/.github/ISSUE_TEMPLATE/social-post.yml
+++ b/.github/ISSUE_TEMPLATE/social-post.yml
@@ -22,4 +22,9 @@ body:
     id: focal_point
     attributes:
       label: Instagram crop focal point (optional)
+      description: >
+        If the hero image doesn't fill the full 1080×1080 crop, the remaining area
+        is filled with white. To use a custom Instagram image instead, place it at
+        docs/public/images/blog/{slug}/hero-instagram.jpg before triggering this workflow
+        — the auto-crop will be skipped if that file already exists.
       placeholder: "top, center, or bottom — defaults to center"

--- a/.github/workflows/social-post.yml
+++ b/.github/workflows/social-post.yml
@@ -129,11 +129,21 @@ jobs:
             exit 0
           fi
 
+          if [ -f "$OUTPUT" ]; then
+            echo "Instagram crop already exists at $OUTPUT — skipping generation (may be a custom image)"
+            echo "generated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           mkdir -p "$(dirname "$OUTPUT")"
 
-          # Resize so smallest dimension is 1080, then gravity-crop to 1080x1080
+          # Resize so smallest dimension is 1080, then gravity-crop to 1080x1080.
+          # If the image is narrower or shorter than 1080px, padding will be added.
+          # White is used as the filler colour — it looks better than black for most
+          # blog hero images, and true transparency is not supported by Instagram.
           convert "$INPUT" \
             -resize "1080x1080^" \
+            -background white \
             -gravity "$GRAVITY" \
             -extent 1080x1080 \
             "$OUTPUT"

--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -285,6 +285,10 @@ jobs:
 
           # 09:00 Europe/Oslo — calculate UTC offset (CET=+01:00, CEST=+02:00)
           import subprocess, datetime
+          today = datetime.date.today()
+          social_date = datetime.date.fromisoformat(post_date)
+          is_future = social_date > today
+
           tz_offset = subprocess.run(
               ['date', '-d', f'{post_date} 09:00:00', '+%z'],
               env={**os.environ, 'TZ': 'Europe/Oslo'}, capture_output=True, text=True
@@ -299,14 +303,26 @@ jobs:
           instagram_media_id = os.environ.get('INSTAGRAM_MEDIA_ID', '')
 
           def schedule(account_id, text, platform, media_id=None):
-              post = {
-                  'accounts': [{'id': account_id, 'scheduled_at': scheduled_at}],
-                  'networks': {platform: {'text': text}}
-              }
+              # Use "photo" type when media is attached, "status" for text-only
+              post_type = 'photo' if media_id else 'status'
+              network = {'type': post_type, 'text': text}
               if media_id:
-                  post['networks'][platform]['media'] = [{'id': media_id, 'type': 'image'}]
+                  network['media'] = [{'id': media_id, 'type': 'image'}]
 
-              payload = json.dumps({'bulk': {'state': 'scheduled', 'posts': [post]}}).encode()
+              # Post immediately if social date is today or in the past
+              if is_future:
+                  state = 'scheduled'
+                  account_entry = {'id': account_id, 'scheduled_at': scheduled_at}
+              else:
+                  state = 'published'
+                  account_entry = {'id': account_id}
+
+              post = {
+                  'accounts': [account_entry],
+                  'networks': {platform: network}
+              }
+
+              payload = json.dumps({'bulk': {'state': state, 'posts': [post]}}).encode()
               req = urllib.request.Request(
                   'https://app.publer.com/api/v1/posts/schedule',
                   data=payload,
@@ -314,6 +330,7 @@ jobs:
                       'Authorization': f'Bearer-API {api_key}',
                       'Publer-Workspace-Id': workspace_id,
                       'Content-Type': 'application/json',
+                      'User-Agent': 'Mozilla/5.0 (compatible; bancs-social-bot/1.0)',
                   }
               )
               try:
@@ -355,22 +372,27 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           python3 << 'PYEOF'
-          import os, subprocess
+          import os, subprocess, datetime
 
           date = os.environ['POST_DATE']
           title = os.environ['POST_TITLE']
+          is_future = datetime.date.fromisoformat(date) > datetime.date.today()
 
-          scheduled = subprocess.run(
-              ['date', '-d', f'{date} 09:00:00', '+%A %B %-d, %Y at 09:00 CET'],
-              env={**os.environ, 'TZ': 'Europe/Oslo'},
-              capture_output=True, text=True
-          ).stdout.strip()
+          if is_future:
+              scheduled = subprocess.run(
+                  ['date', '-d', f'{date} 09:00:00', '+%A %B %-d, %Y at 09:00 CET'],
+                  env={**os.environ, 'TZ': 'Europe/Oslo'},
+                  capture_output=True, text=True
+              ).stdout.strip()
+              heading = f'## Scheduled for {scheduled}'
+          else:
+              heading = '## Posted immediately'
 
           def status(val):
               return 'checked' if val == 'true' else 'x'
 
           lines = [
-              f'## Scheduled for {scheduled}',
+              heading,
               '',
               f'**{title}**',
               '',


### PR DESCRIPTION
Closes #218

## Summary
- Fix Twitter rejections and LinkedIn missing images by adding required type field to Publer network payloads (`photo` with media, `status` without)
- Post immediately when social date is today or past; schedule only for future dates
- Skip Instagram crop generation if `hero-instagram.jpg` already exists, preserving custom images
- Use white background for Instagram letterboxing (was black)
- Document crop behaviour and custom image override in issue template

## Test plan
- [ ] Merge a blog post PR with a future `socialDate` — verify posts are scheduled in Publer with images attached
- [ ] Merge a blog post PR with today's date — verify posts go out immediately
- [ ] Run social-post backfill on a post with existing `hero-instagram.jpg` — verify it is not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)