### PR TITLE
chore(ci): install ImageMagick before Instagram crop step

### DIFF
--- a/.github/workflows/social-post.yml
+++ b/.github/workflows/social-post.yml
@@ -113,6 +113,9 @@ jobs:
           print(f'Hero image: {hero_image}')
           PYEOF
 
+      - name: Install ImageMagick
+        run: sudo apt-get install -y imagemagick
+
       - name: Generate Instagram crop
         id: crop
         env:


### PR DESCRIPTION
Closes #223

## Summary
- Add `apt-get install imagemagick` step to `social-post.yml` — ImageMagick is not pre-installed on `ubuntu-latest` runners, causing the Instagram crop step to fail with `convert: command not found`

## Test plan
- [ ] Re-run issue #222 (or a new `social-post` issue) and verify the Instagram crop step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)