### PR TITLE
chore(ci): skip triage for bot actors and structured issue labels

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    if: >-
+      github.event.sender.type == 'User' &&
+      !contains(github.event.issue.labels.*.name, 'social-post') &&
+      !contains(github.event.issue.labels.*.name, 'upcoming-post')
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #224

## Summary
- Add job-level `if` condition to skip the triage job entirely for bot actors (`sender.type != 'User'`)
- Skip triage for issues labelled `social-post` or `upcoming-post`

## Test plan
- [x] Open a `social-post` issue — no triage comment appears
- [x] Open an `upcoming-post` issue — no triage comment appears
- [x] Open a regular issue as a user — triage runs normally
- [x] Verify bot-created issues do not trigger the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)