### PR TITLE
chore(ci): add paths filter to social-schedule workflow trigger

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -5,6 +5,8 @@ on:
     types: [closed]
     branches:
       - main
+    paths:
+      - 'docs/blog/**'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Closes #227

## Summary
- Add `paths: docs/blog/**` to the `pull_request` trigger so the workflow only starts on PRs that touch blog files — skips all other merges

## Test plan
- [x] Merge a non-blog PR and verify `social-schedule` does not trigger
- [x] Merge a blog post PR and verify `social-schedule` still triggers normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)