### PR TITLE
chore: align upcoming-post template with UpcomingPage.vue parser contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/upcoming-post.yml
+++ b/.github/ISSUE_TEMPLATE/upcoming-post.yml
@@ -26,6 +26,7 @@ body:
     id: tags
     attributes:
       label: Tags
+      description: "Comma-separated, e.g. claude-code, methodology, open-source"
       placeholder: "claude-code, methodology, open-source"
 
   - type: textarea
@@ -58,8 +59,8 @@ body:
       label: Key Takeaways
       description: 3–5 bullet points the reader walks away with.
       value: |
-        -
-        -
-        -
+        - First takeaway
+        - Second takeaway
+        - Third takeaway
     validations:
       required: true


### PR DESCRIPTION
Closes #221

## Summary
- Add description to Tags field making comma-separated format explicit
- Fix Key Takeaways pre-fill from bare `-` to `- Text` so the parser's `startsWith('- ')` check passes and takeaways render correctly

## Test plan
- [x] Open a new upcoming-post issue via the template — Key Takeaways pre-fills with `- First takeaway` style starters
- [x] Tags field shows the comma-separated description hint
- [x] Submit a test issue and verify UpcomingPage.vue renders tags and takeaways correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)