### PR TITLE
chore: add socialDate to new-blog-post command template

### DIFF
--- a/.claude/commands-templates/new-blog-post.md
+++ b/.claude/commands-templates/new-blog-post.md
@@ -22,7 +22,8 @@ This command helps you create a new blog post following the project's blog workf
    - Create: `docs/blog/{slug}.md`
    - Use the template from CONTRIBUTING.md
    - Fill in title, author, topics
-   - Add current date
+   - Add current date as `date: YYYY-MM-DD`
+   - Add `socialDate: YYYY-MM-DD` with the same value as `date` (author can change it independently before publishing)
    - Include placeholder sections (Introduction, Main Content, Conclusion)
 
 4. **Create Examples Directory**


### PR DESCRIPTION
Closes #219

## Summary
- Add `socialDate: YYYY-MM-DD` to the frontmatter instructions in the new-blog-post command template, defaulting to the same value as `date`
- Removes the silent fallback in `social-schedule.yml` — every new post now has an explicit field the author can override before publishing

## Test plan
- [x] Run `/new-blog-post` and verify generated frontmatter includes both `date` and `socialDate` with the same value

🤖 Generated with [Claude Code](https://claude.com/claude-code)