### PR TITLE
chore(ci): gate upcoming-post label on maintainer author_association

### DIFF
--- a/.github/ISSUE_TEMPLATE/upcoming-post.yml
+++ b/.github/ISSUE_TEMPLATE/upcoming-post.yml
@@ -1,6 +1,5 @@
 name: Upcoming Blog Post
 description: Plan and track an upcoming post for bancs.no
-labels: ["upcoming-post"]
 body:
   - type: input
     id: title

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -36,6 +36,7 @@ jobs:
             - Issue title: ${{ github.event.issue.title }}
             - Issue body: ${{ github.event.issue.body }}
             - Issue author: ${{ github.event.issue.user.login }}
+            - Author association: ${{ github.event.issue.author_association }}
             - Current labels: ${{ join(github.event.issue.labels.*.name, ', ') }}
 
             Your job depends on the event type:
@@ -64,6 +65,11 @@ jobs:
             - Remove `status: closed` label if present
             - Add `status: needs-triage` label
             - Post a comment noting the issue was reopened and needs re-evaluation
+
+            ## Special handling: upcoming-post template
+            If the issue body matches the upcoming-post template (contains fields like "Post Title", "Summary", "Sections", "Key Takeaways"):
+            - If author_association is OWNER, MEMBER, or COLLABORATOR: apply the `upcoming-post` label and skip normal triage labeling
+            - Otherwise: do NOT apply `upcoming-post`; post a comment thanking them and explaining the `upcoming-post` label is applied by a maintainer after review
 
             ## General rules
             - Be concise in comments — one short paragraph is enough


### PR DESCRIPTION
Closes #232

## Summary
- Remove auto-label from `upcoming-post.yml` — external users can no longer trigger site rendering by opening an issue via the template
- Gate the `upcoming-post` label in `issue-triage.yml` on `author_association` (OWNER/MEMBER/COLLABORATOR only); external contributors get a polite comment explaining a maintainer will review

## Test plan
- [x] Open an upcoming-post issue as an external user — verify no `upcoming-post` label is applied and a comment appears
- [x] Open an upcoming-post issue as a maintainer — verify `upcoming-post` label is applied automatically by triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)