### PR TITLE
chore(ci): add id-token: write permission to social-schedule workflow

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  id-token: write
 
 jobs:
   schedule-social:


### PR DESCRIPTION
Closes #244

## Summary
- Add missing `id-token: write` permission so `claude-code-action` can fetch an OIDC token — without it the workflow fails before generating any social content

## Test plan
- [x] Merge a blog post PR and verify `social-schedule.yml` completes without the OIDC token error

🤖 Generated with [Claude Code](https://claude.com/claude-code)