### PR TITLE
chore(ci): distinguish crop-exists from hero-not-found in social-post PR body

### DIFF
--- a/.github/workflows/social-post.yml
+++ b/.github/workflows/social-post.yml
@@ -129,12 +129,14 @@ jobs:
           if [ ! -f "$INPUT" ]; then
             echo "Hero image not found at $INPUT — skipping crop"
             echo "generated=false" >> $GITHUB_OUTPUT
+            echo "skipped_reason=no_hero" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           if [ -f "$OUTPUT" ]; then
             echo "Instagram crop already exists at $OUTPUT — skipping generation (may be a custom image)"
             echo "generated=false" >> $GITHUB_OUTPUT
+            echo "skipped_reason=exists" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -203,6 +205,7 @@ jobs:
           SOCIAL_DATE: ${{ steps.parse.outputs.social_date }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           CROP_GENERATED: ${{ steps.crop.outputs.generated }}
+          CROP_SKIPPED_REASON: ${{ steps.crop.outputs.skipped_reason }}
         run: |
           BRANCH="fix/social-post-${SLUG}-${SOCIAL_DATE}"
 
@@ -220,7 +223,13 @@ jobs:
           git push origin "$BRANCH"
 
           CROP_NOTE=""
-          [ "$CROP_GENERATED" = "true" ] && CROP_NOTE="- Instagram crop generated at \`docs/public/images/blog/${SLUG}/hero-instagram.jpg\`" || CROP_NOTE="- ⚠️ Hero image not found — Instagram crop skipped"
+          if [ "$CROP_GENERATED" = "true" ]; then
+            CROP_NOTE="- Instagram crop generated at \`docs/public/images/blog/${SLUG}/hero-instagram.jpg\`"
+          elif [ "$CROP_SKIPPED_REASON" = "exists" ]; then
+            CROP_NOTE="- Instagram crop already exists — skipped"
+          else
+            CROP_NOTE="- ⚠️ Hero image not found — Instagram crop skipped"
+          fi
 
           gh pr create \
             --title "fix: add socialDate for ${SLUG} (${SOCIAL_DATE})" \


### PR DESCRIPTION
Closes #243

## Summary
- Add `skipped_reason=exists|no_hero` output to the crop step
- PR body now shows three distinct messages: crop generated, crop already exists (informational), or hero image not found (⚠️ warning)

## Test plan
- [x] Open a social-post issue for a post whose Instagram crop already exists — verify PR body says "already exists" not "hero not found"
- [x] Verify ⚠️ warning still appears when hero image is genuinely missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)