### PR TITLE
chore(ci): allow Claude to write files in social-schedule workflow

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -146,6 +146,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--allowedTools Write"
           prompt: |
             You are a social media copywriter for Benny Molowny Thomas, a Norwegian solo developer
             and consultant at BANCS AS. He writes about Claude Code methodology, open source, and


### PR DESCRIPTION
Closes #249

## Summary
- Add `claude_args: "--allowedTools Write"` to the Generate social content step — `claude-code-action@v1` defaults to read-only, causing Claude to silently fail when writing `/tmp/claude-output.json`

## Test plan
- [x] social-schedule runs on a merged blog PR — Claude step succeeds
- [x] `/tmp/claude-output.json` is written and validated
- [x] Posts are scheduled via Publer as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)