### PR TITLE
chore(ci): switch Claude allowedTool from Write to Bash in social-schedule

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -146,7 +146,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowedTools Write"
+          claude_args: "--allowedTools Bash"
           prompt: |
             You are a social media copywriter for Benny Molowny Thomas, a Norwegian solo developer
             and consultant at BANCS AS. He writes about Claude Code methodology, open source, and


### PR DESCRIPTION
Closes #255

## Summary
- Replace `--allowedTools Write` with `--allowedTools Bash` — `Write` is workspace-scoped and can't reach `/tmp/`; Claude uses Bash (python3) to write `/tmp/claude-output.json` so Bash permission is what's needed

## Test plan
- [x] social-schedule runs on a merged blog PR — Claude step succeeds
- [x] `/tmp/claude-output.json` is written and validated
- [x] Posts are scheduled via Publer as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)