### PR TITLE
fix: add socialDate for stalactite-autodream (2026-04-05)

### DIFF
--- a/docs/blog/stalactite-autodream.md
+++ b/docs/blog/stalactite-autodream.md
@@ -23,7 +23,7 @@ hero:
     license: Public Domain
     licenseUrl: https://creativecommons.org/publicdomain/zero/1.0/
   instagram: /images/blog/stalactite-autodream/hero-instagram.jpg
-socialDate: '2026-04-06'
+socialDate: '2026-04-05'
 ---
 
 <BlogHeading />


### PR DESCRIPTION
Closes #257

## Summary
- `socialDate: 2026-04-05` added to frontmatter
- Instagram crop already exists — skipped

When this PR merges, `social-schedule.yml` will pick up the `socialDate` and schedule posts via Publer at 09:00 Europe/Oslo.