### PR TITLE
chore(ci): add Read to allowedTools and CLAUDE_DEBUG output toggle

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -146,7 +146,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--allowedTools Bash"
+          claude_args: "--allowedTools Read,Bash"
+          show_full_output: ${{ vars.CLAUDE_DEBUG || 'false' }}
           prompt: |
             You are a social media copywriter for Benny Molowny Thomas, a Norwegian solo developer
             and consultant at BANCS AS. He writes about Claude Code methodology, open source, and


### PR DESCRIPTION
Closes #259

## Summary
- Add `Read` to `--allowedTools` so Claude can read `/tmp/post_content.md` — explicit `allowedTools` list replaces defaults, so `Read` was missing
- Add `show_full_output` toggled by `vars.CLAUDE_DEBUG` repo variable for debugging tool calls without polluting normal runs

## Test plan
- [x] social-schedule runs — Claude step succeeds with no permission denials
- [x] `/tmp/claude-output.json` is written and validated
- [x] Posts are scheduled via Publer as expected
- [x] Setting `CLAUDE_DEBUG=true` repo variable shows full Claude output

🤖 Generated with [Claude Code](https://claude.com/claude-code)