### PR TITLE
chore(ci): schedule today's social posts 30 min from now

### DIFF
--- a/.github/workflows/social-schedule.yml
+++ b/.github/workflows/social-schedule.yml
@@ -294,11 +294,16 @@ jobs:
           social_date = datetime.date.fromisoformat(post_date)
           is_future = social_date > today
 
-          tz_offset = subprocess.run(
-              ['date', '-d', f'{post_date} 09:00:00', '+%z'],
-              env={**os.environ, 'TZ': 'Europe/Oslo'}, capture_output=True, text=True
-          ).stdout.strip()
-          scheduled_at = f'{post_date}T09:00:00{tz_offset[:3]}:{tz_offset[3:]}'
+          if is_future:
+              tz_offset = subprocess.run(
+                  ['date', '-d', f'{post_date} 09:00:00', '+%z'],
+                  env={**os.environ, 'TZ': 'Europe/Oslo'}, capture_output=True, text=True
+              ).stdout.strip()
+              scheduled_at = f'{post_date}T09:00:00{tz_offset[:3]}:{tz_offset[3:]}'
+          else:
+              # Schedule 30 minutes from now — gives time to review before it goes out
+              now_plus_30 = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30)
+              scheduled_at = now_plus_30.strftime('%Y-%m-%dT%H:%M:%S+00:00')
 
           with open('/tmp/linkedin_post.txt') as f:
               linkedin_text = f.read()
@@ -314,13 +319,8 @@ jobs:
               if media_id:
                   network['media'] = [{'id': media_id, 'type': 'image'}]
 
-              # Post immediately if social date is today or in the past
-              if is_future:
-                  state = 'scheduled'
-                  account_entry = {'id': account_id, 'scheduled_at': scheduled_at}
-              else:
-                  state = 'published'
-                  account_entry = {'id': account_id}
+              state = 'scheduled'
+              account_entry = {'id': account_id, 'scheduled_at': scheduled_at}
 
               post = {
                   'accounts': [account_entry],
@@ -391,7 +391,8 @@ jobs:
               ).stdout.strip()
               heading = f'## Scheduled for {scheduled}'
           else:
-              heading = '## Posted immediately'
+              now_plus_30 = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30)
+              heading = f'## Scheduled for today at {now_plus_30.strftime("%H:%M")} UTC (~30 min from now)'
 
           def status(val):
               return 'checked' if val == 'true' else 'x'


### PR DESCRIPTION
Closes #267

## Summary
- Remove invalid `state='published'` — Publer API rejects it with `{"errors":["Unknown state published"]}`
- When post date is today or past, compute `scheduled_at = now + 30min UTC`
- Update PR comment heading to show actual scheduled time instead of "Posted immediately"

## Test plan
- [x] Trigger social-schedule on a post with today's date — all three platforms should schedule successfully
- [x] Verify PR comment shows "Scheduled for today at HH:MM UTC (~30 min from now)"
- [x] Trigger on a future-dated post — verify 09:00 Oslo scheduling is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)