### PR TITLE
chore(ci): add ESLint to PR validation and fix all lint errors

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -31,6 +31,9 @@ jobs:
           HUSKY: 0
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Validate blog styles
         run: npm run validate:styles
 

--- a/docs/.vitepress/theme/components/BlogIndex.vue
+++ b/docs/.vitepress/theme/components/BlogIndex.vue
@@ -7,20 +7,36 @@ const publishedPosts = posts.filter(post => post.isPublished)
 </script>
 
 <template>
-  <BlogCard v-for="post in publishedPosts" :key="post.url">
+  <BlogCard
+    v-for="post in publishedPosts"
+    :key="post.url"
+  >
     <h3 class="mt-0 mb-3">
-      <a :href="post.url" class="text-[var(--vp-c-brand-1)] hover:text-[var(--vp-c-brand-2)] no-underline">{{ post.title }}</a>
+      <a
+        :href="post.url"
+        class="text-[var(--vp-c-brand-1)] hover:text-[var(--vp-c-brand-2)] no-underline"
+      >{{ post.title }}</a>
     </h3>
-    <p class="mb-4 leading-relaxed"><strong>Date</strong>: {{ post.date.string }}</p>
+    <p class="mb-4 leading-relaxed">
+      <strong>Date</strong>: {{ post.date.string }}
+    </p>
 
-    <p class="mb-4 leading-relaxed">{{ post.description }}</p>
+    <p class="mb-4 leading-relaxed">
+      {{ post.description }}
+    </p>
 
-    <p v-if="post.tags && post.tags.length > 0" class="mb-4 leading-relaxed">
+    <p
+      v-if="post.tags && post.tags.length > 0"
+      class="mb-4 leading-relaxed"
+    >
       <strong>Topics</strong>: {{ post.tags.join(', ') }}
     </p>
 
     <p class="mb-0 leading-relaxed">
-      <a :href="post.url" class="text-[var(--vp-c-brand-1)] hover:text-[var(--vp-c-brand-2)] no-underline">Read more →</a>
+      <a
+        :href="post.url"
+        class="text-[var(--vp-c-brand-1)] hover:text-[var(--vp-c-brand-2)] no-underline"
+      >Read more →</a>
     </p>
   </BlogCard>
 </template>

--- a/docs/.vitepress/theme/components/HeroImage.vue
+++ b/docs/.vitepress/theme/components/HeroImage.vue
@@ -125,7 +125,10 @@ const imageClasses = computed(() => [
     </div>
 
     <!-- Attribution slot -->
-    <div v-if="$slots.default" class="text-xs text-gray-500 dark:text-gray-400 italic mt-2 text-center">
+    <div
+      v-if="$slots.default"
+      class="text-xs text-gray-500 dark:text-gray-400 italic mt-2 text-center"
+    >
       <slot />
     </div>
   </div>

--- a/docs/.vitepress/theme/components/ImageAttribution.vue
+++ b/docs/.vitepress/theme/components/ImageAttribution.vue
@@ -9,22 +9,36 @@ interface Props {
   modifications?: string
 }
 
-const props = defineProps<Props>()
+const _props = defineProps<Props>()
 </script>
 
 <template>
   <span>
     Photo by
-    <a v-if="authorUrl" :href="authorUrl" target="_blank" rel="noopener">{{ author }}</a>
+    <a
+      v-if="authorUrl"
+      :href="authorUrl"
+      target="_blank"
+      rel="noopener"
+    >{{ author }}</a>
     <span v-else>{{ author }}</span>
     <template v-if="source || sourceUrl">
       on
-      <a v-if="sourceUrl" :href="sourceUrl" target="_blank" rel="noopener">{{ source || 'source' }}</a>
+      <a
+        v-if="sourceUrl"
+        :href="sourceUrl"
+        target="_blank"
+        rel="noopener"
+      >{{ source || 'source' }}</a>
       <span v-else>{{ source }}</span>
     </template>
     <template v-if="license">
       <template v-if="licenseUrl">
-        , <a :href="licenseUrl" target="_blank" rel="noopener">{{ license }}</a>
+        , <a
+          :href="licenseUrl"
+          target="_blank"
+          rel="noopener"
+        >{{ license }}</a>
       </template>
       <template v-else>
         , {{ license }}

--- a/docs/.vitepress/theme/components/PostPreview.vue
+++ b/docs/.vitepress/theme/components/PostPreview.vue
@@ -41,11 +41,11 @@ const badgeClasses = computed(() => [
     </div>
 
     <!-- Stamp slot (rendered outside blurred content) -->
-    <slot name="stamp"></slot>
+    <slot name="stamp" />
 
     <!-- Content wrapper with blur -->
     <div :class="contentClasses">
-      <slot></slot>
+      <slot />
     </div>
   </div>
 </template>

--- a/docs/.vitepress/theme/components/RevealStamp.vue
+++ b/docs/.vitepress/theme/components/RevealStamp.vue
@@ -101,7 +101,11 @@ const stampResponsiveClasses = computed(() => {
 
 <template>
   <div :class="[variantClasses, stampResponsiveClasses]">
-    <div :class="textClasses">{{ text }}</div>
-    <div :class="dateClasses">{{ date }}</div>
+    <div :class="textClasses">
+      {{ text }}
+    </div>
+    <div :class="dateClasses">
+      {{ date }}
+    </div>
   </div>
 </template>

--- a/docs/.vitepress/theme/components/SeriesNav.vue
+++ b/docs/.vitepress/theme/components/SeriesNav.vue
@@ -10,7 +10,7 @@ interface Props {
   }
 }
 
-const props = defineProps<Props>()
+const _props = defineProps<Props>()
 </script>
 
 <template>

--- a/docs/.vitepress/theme/components/UpcomingPage.vue
+++ b/docs/.vitepress/theme/components/UpcomingPage.vue
@@ -202,14 +202,19 @@ onMounted(async () => {
 
 <template>
   <div class="max-w-3xl mx-auto px-4 py-12 sm:py-16">
-
     <!-- Loading -->
-    <p v-if="state === 'loading'" class="text-[var(--vp-c-text-2)] italic text-center py-16">
+    <p
+      v-if="state === 'loading'"
+      class="text-[var(--vp-c-text-2)] italic text-center py-16"
+    >
       Loading...
     </p>
 
     <!-- Redirecting -->
-    <p v-else-if="state === 'redirecting'" class="text-[var(--vp-c-text-2)] italic text-center py-16">
+    <p
+      v-else-if="state === 'redirecting'"
+      class="text-[var(--vp-c-text-2)] italic text-center py-16"
+    >
       Taking you to the published post...
     </p>
 
@@ -236,7 +241,6 @@ onMounted(async () => {
 
     <!-- Preview -->
     <template v-else-if="state === 'preview' && post">
-
       <!-- Under construction hero -->
       <div class="flex flex-col items-center mb-10">
         <picture class="flex justify-center w-full max-h-[28vh]">
@@ -268,13 +272,19 @@ onMounted(async () => {
 
       <!-- Meta row -->
       <div class="flex flex-wrap items-center gap-x-4 gap-y-2 mb-8 text-sm text-[var(--vp-c-text-2)]">
-        <span v-if="post.series" class="font-medium text-[var(--vp-c-brand-1)]">
+        <span
+          v-if="post.series"
+          class="font-medium text-[var(--vp-c-brand-1)]"
+        >
           {{ post.series }}
         </span>
         <span v-if="post.estimated">
           {{ post.estimated }}
         </span>
-        <div v-if="post.tags.length > 0" class="flex flex-wrap gap-1">
+        <div
+          v-if="post.tags.length > 0"
+          class="flex flex-wrap gap-1"
+        >
           <span
             v-for="tag in post.tags"
             :key="tag"
@@ -284,12 +294,18 @@ onMounted(async () => {
       </div>
 
       <!-- Summary -->
-      <p v-if="post.summary" class="text-lg leading-relaxed text-[var(--vp-c-text-1)] mb-10">
+      <p
+        v-if="post.summary"
+        class="text-lg leading-relaxed text-[var(--vp-c-text-1)] mb-10"
+      >
         {{ post.summary }}
       </p>
 
       <!-- Planned sections -->
-      <div v-if="post.sections.length > 0" class="mb-10">
+      <div
+        v-if="post.sections.length > 0"
+        class="mb-10"
+      >
         <h2 class="!text-xl font-semibold mb-4 text-[var(--vp-c-text-1)] border-b border-[var(--vp-c-divider)] pb-2">
           Planned sections
         </h2>
@@ -304,7 +320,10 @@ onMounted(async () => {
             </span>
             <div>
               <span class="font-semibold text-[var(--vp-c-text-1)]">{{ sec.title }}</span>
-              <span v-if="sec.description" class="block text-sm text-[var(--vp-c-text-2)] mt-0.5">
+              <span
+                v-if="sec.description"
+                class="block text-sm text-[var(--vp-c-text-2)] mt-0.5"
+              >
                 {{ sec.description }}
               </span>
             </div>
@@ -313,7 +332,10 @@ onMounted(async () => {
       </div>
 
       <!-- Key takeaways -->
-      <div v-if="post.takeaways.length > 0" class="mb-10">
+      <div
+        v-if="post.takeaways.length > 0"
+        class="mb-10"
+      >
         <h2 class="!text-xl font-semibold mb-4 text-[var(--vp-c-text-1)] border-b border-[var(--vp-c-divider)] pb-2">
           Key takeaways
         </h2>
@@ -333,9 +355,16 @@ onMounted(async () => {
       <div class="mt-12 pt-8 border-t border-[var(--vp-c-divider)] text-center">
         <p class="text-[var(--vp-c-text-2)] mb-4">
           Want to know when this publishes? Follow us on
-          <a href="https://github.com/BANCS-Norway" class="text-[var(--vp-c-brand-1)] no-underline hover:underline" rel="noopener">GitHub</a>
+          <a
+            href="https://github.com/BANCS-Norway"
+            class="text-[var(--vp-c-brand-1)] no-underline hover:underline"
+            rel="noopener"
+          >GitHub</a>
           or subscribe to the
-          <a href="/blog/" class="text-[var(--vp-c-brand-1)] no-underline hover:underline">RSS feed</a>.
+          <a
+            href="/blog/"
+            class="text-[var(--vp-c-brand-1)] no-underline hover:underline"
+          >RSS feed</a>.
         </p>
         <a
           href="/blog/"
@@ -344,8 +373,6 @@ onMounted(async () => {
           Back to the blog
         </a>
       </div>
-
     </template>
-
   </div>
 </template>

--- a/docs/.vitepress/theme/components/UpcomingPosts.vue
+++ b/docs/.vitepress/theme/components/UpcomingPosts.vue
@@ -79,18 +79,36 @@ onMounted(async () => {
 </script>
 
 <template>
-  <p v-if="loading" class="text-[var(--vp-c-text-2)] italic">Loading...</p>
+  <p
+    v-if="loading"
+    class="text-[var(--vp-c-text-2)] italic"
+  >
+    Loading...
+  </p>
 
   <template v-else-if="!error">
     <h2>Planned posts</h2>
-    <ul v-if="posts.length > 0" class="list-none p-0">
-      <li v-for="post in posts" :key="post.number" class="mb-4">
+    <ul
+      v-if="posts.length > 0"
+      class="list-none p-0"
+    >
+      <li
+        v-for="post in posts"
+        :key="post.number"
+        class="mb-4"
+      >
         <a
           :href="`/upcoming?issue=${post.number}`"
           class="text-[var(--vp-c-brand-1)] hover:text-[var(--vp-c-brand-2)] font-medium no-underline"
         >{{ post.title }}</a>
-        <span v-if="post.estimated" class="text-[var(--vp-c-text-2)] text-sm ml-2">— {{ post.estimated }}</span>
-        <div v-if="post.tags.length > 0" class="flex flex-wrap gap-1 mt-1">
+        <span
+          v-if="post.estimated"
+          class="text-[var(--vp-c-text-2)] text-sm ml-2"
+        >— {{ post.estimated }}</span>
+        <div
+          v-if="post.tags.length > 0"
+          class="flex flex-wrap gap-1 mt-1"
+        >
           <span
             v-for="tag in post.tags"
             :key="tag"
@@ -100,7 +118,10 @@ onMounted(async () => {
       </li>
     </ul>
 
-    <p v-else class="text-[var(--vp-c-text-2)] italic">
+    <p
+      v-else
+      class="text-[var(--vp-c-text-2)] italic"
+    >
       Nothing planned yet — watch this space.
     </p>
   </template>

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -74,6 +74,8 @@ export default [
         document: 'readonly',
         window: 'readonly',
         navigator: 'readonly',
+        fetch: 'readonly',
+        URLSearchParams: 'readonly',
       },
     },
     rules: {

--- a/scripts/carousel/builder.ts
+++ b/scripts/carousel/builder.ts
@@ -31,7 +31,7 @@ const FONTS_DIR  = resolve(__dirname, 'fonts');
 // ---------------------------------------------------------------------------
 
 const KNOWN_FONTS: Record<string, string> = {
-  'Inter':        'Inter-Regular.ttf',
+  Inter:        'Inter-Regular.ttf',
   'Inter-Bold':   'Inter-Bold.ttf',
   'Inter-Medium': 'Inter-Medium.ttf',
 };
@@ -136,7 +136,7 @@ export async function addUriAnnotation(pdfBytes: Uint8Array, def: CarouselTempla
   const urlFieldDef = def.tail.find(f => f.name === def.urlField);
   if (!urlFieldDef) throw new Error(`urlField "${def.urlField}" not found in tail schema`);
 
-  const { W, H } = def.dimensions;
+  const { W: _W, H } = def.dimensions;
   const MM = 72 / 25.4;
 
   const x = urlFieldDef.position.x * MM;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,11 +22,11 @@ export default {
       },
       keyframes: {
         reveal: {
-          'from': {
+          from: {
             filter: 'blur(5px)',
             opacity: '0.7',
           },
-          'to': {
+          to: {
             filter: 'blur(0)',
             opacity: '1',
           },


### PR DESCRIPTION
Closes #286

## Summary
- Add lint step to PR validation workflow so ESLint runs on every PR
- Fix 4 `no-undef` errors by declaring `fetch` and `URLSearchParams` as browser globals in `eslint.config.ts`
- Fix 3 unused variable warnings (`props` → `_props` in two components, `W` → `_W` in carousel builder)
- Auto-fix 43 formatting warnings across Vue components and config files

## Test plan
- [x] Open a PR and verify the Lint step runs and passes in CI
- [x] Verify a PR with an ESLint error is blocked by the lint step

🤖 Generated with [Claude Code](https://claude.com/claude-code)