### PR TITLE
fix: add socialDate for serverless-offline-sns-stewardship (2026-04-09)

### DIFF
--- a/docs/blog/serverless-offline-sns-stewardship.md
+++ b/docs/blog/serverless-offline-sns-stewardship.md
@@ -1,14 +1,16 @@
 ---
 title: Giving Back - Taking Stewardship of serverless-offline-sns
-description: BANCS has formally taken over maintenance of serverless-offline-sns after nearly 10 years under its original author. Here's the full story of why we stepped up, what we found, and what we've done with it.
+description: BANCS has formally taken over maintenance of serverless-offline-sns after
+  nearly 10 years under its original author. Here's the full story of why we stepped
+  up, what we found, and what we've done with it.
 date: 2026-02-27
 readingTime: 9
 tags:
-  - open-source
-  - serverless
-  - aws
-  - community
-  - stewardship
+- open-source
+- serverless
+- aws
+- community
+- stewardship
 hero:
   image: /images/blog/serverless-offline-sns-stewardship.jpg
   alt: A lighthouse standing firm against crashing waves in black and white
@@ -20,6 +22,7 @@ hero:
     license: Unsplash License
     licenseUrl: https://unsplash.com/license
     modifications: Converted to grayscale
+socialDate: '2026-04-09'
 ---
 
 <BlogHeading />


### PR DESCRIPTION
Closes #291

## Summary
- `socialDate: 2026-04-09` added to frontmatter

When this PR merges, `social-schedule.yml` will pick up the `socialDate` and schedule posts via Publer at 09:00 Europe/Oslo.