### PR TITLE
fix: add socialDate for stalactite-autodream (2026-04-15)

### DIFF
--- a/docs/blog/stalactite-autodream.md
+++ b/docs/blog/stalactite-autodream.md
@@ -22,7 +22,7 @@ hero:
     sourceUrl: https://commons.wikimedia.org/wiki/File:NNC-US-1907-G%2420-Saint_Gaudens_(Roman,_ultra_high_relief,_wire_edge).jpg
     license: Public Domain
     licenseUrl: https://creativecommons.org/publicdomain/zero/1.0/
-socialDate: '2026-04-06'
+socialDate: '2026-04-15'
 ---
 
 <BlogHeading />


### PR DESCRIPTION
Closes #292

## Summary
- `socialDate: 2026-04-15` added to frontmatter

When this PR merges, `social-schedule.yml` will pick up the `socialDate` and schedule posts via Publer at 09:00 Europe/Oslo.