### PR TITLE
chore(ci): rewrite LinkedIn prompt to generate a short hook

### DIFF
--- a/scripts/prompts/social-content.txt
+++ b/scripts/prompts/social-content.txt
@@ -12,7 +12,7 @@ Read the full blog post content from /tmp/post_content.md.
 Generate social media content and write it as valid JSON to /tmp/claude-output.json
 with exactly this structure — no markdown fences, no explanation, just the JSON:
 {
-  "linkedin_body": "Post body mirroring H2 sections with condensed text and code blocks interleaved as in the original. Ends with: Read the complete article: $URL. No disclaimer or attribution — those are added separately.",
+  "linkedin_body": "2-3 sentences max. Open with the most interesting or surprising angle from the post — not a summary, not a list of sections. The carousel covers the content; this is just the hook that makes someone stop scrolling. End with: Read the complete article: $URL. No disclaimer or attribution — those are added separately.",
   "twitter": "Max 280 chars. Punchy and direct. URL is appended separately — do not include it.",
   "instagram_body": "150-250 chars. Conversational and human — not a LinkedIn excerpt. No URL, no hashtags.",
   "instagram_hashtags": ["3-5 relevant hashtags as plain words without the # prefix, e.g. ClaudeCode"]

--- a/scripts/prompts/validate-output.txt
+++ b/scripts/prompts/validate-output.txt
@@ -26,7 +26,7 @@ Quality signals (judgement — be honest and direct):
 - Tone: direct, technically credible, occasionally dry — no hype language, no fluff
 - Twitter: punchy and specific — does it make you want to click?
 - Instagram: conversational and human — does it feel native to the platform? Are the hashtags relevant?
-- LinkedIn body: does it mirror the H2 structure of the original post? Does it condense faithfully without losing the key insights?
+- LinkedIn body: does it open with a compelling hook? Is it 2-3 sentences max? Does it avoid reproducing the article structure — the carousel does that?
 - Carousel template choice: is the chosen template appropriate for the post topic?
 - Carousel head caption: does it make someone want to swipe?
 - Carousel pages: do the eyebrow/title/body combinations work as standalone slide content? Is each slide's big point clear at a glance?


### PR DESCRIPTION
Closes #297

## Summary
- LinkedIn text was reproducing the full article structure — the carousel is the content, the text just needs to be a hook
- Rewrote `linkedin_body` instruction in `social-content.txt`: 2-3 sentences max, open with the most surprising angle, explicitly not a summary of sections
- Updated validator quality signal in `validate-output.txt` to match the new expectation
- Verified locally — output went from a full article mirror to a tight 3-sentence hook

## Test plan
- [ ] Merge and verify next social post scheduled via Publer has a short LinkedIn hook rather than a condensed article

🤖 Generated with [Claude Code](https://claude.com/claude-code)