### PR TITLE
fix: add socialDate for serverless-offline-sns-stewardship (2026-04-10)

### DIFF
--- a/docs/blog/serverless-offline-sns-stewardship.md
+++ b/docs/blog/serverless-offline-sns-stewardship.md
@@ -22,7 +22,7 @@ hero:
     license: Unsplash License
     licenseUrl: https://unsplash.com/license
     modifications: Converted to grayscale
-socialDate: '2026-04-09'
+socialDate: '2026-04-10'
 ---
 
 <BlogHeading />


### PR DESCRIPTION
Closes #299

## Summary
- `socialDate: 2026-04-10` added to frontmatter

When this PR merges, `social-schedule.yml` will pick up the `socialDate` and schedule posts via Publer at 09:00 Europe/Oslo.