### PR TITLE
chore(ci): prevent unescaped quotes in JSON social content output

### DIFF
--- a/scripts/prompts/social-content.txt
+++ b/scripts/prompts/social-content.txt
@@ -10,7 +10,10 @@ Post URL: $URL
 Read the full blog post content from /tmp/post_content.md.
 
 Generate social media content and write it as valid JSON to /tmp/claude-output.json
-with exactly this structure — no markdown fences, no explanation, just the JSON:
+with exactly this structure — no markdown fences, no explanation, just the JSON.
+
+IMPORTANT: All string values must be valid JSON strings. Do NOT use double-quote characters
+inside a value — rephrase to avoid them entirely. Single quotes are fine.
 {
   "linkedin_body": "2-3 sentences max. Open with the most interesting or surprising angle from the post — not a summary, not a list of sections. The carousel covers the content; this is just the hook that makes someone stop scrolling. End with: Read the complete article: $URL. No disclaimer or attribution — those are added separately.",
   "twitter": "Max 280 chars. Punchy and direct. URL is appended separately — do not include it.",

--- a/scripts/prompts/validate-output.txt
+++ b/scripts/prompts/validate-output.txt
@@ -8,6 +8,7 @@ Read the following files:
 Evaluate the generated content against these hard constraints and quality signals.
 
 Hard constraints (measurable — check exactly):
+- json_validity: read /tmp/claude-output.json as raw text and verify it contains no unescaped double-quote characters inside string values — this is the most common cause of invalid JSON
 - twitter: max 280 characters, must NOT contain a URL
 - instagram_body: 150–250 characters, conversational, must NOT contain a URL or hashtags
 - instagram_hashtags: array of 3–5 plain strings without the # prefix
@@ -36,6 +37,7 @@ Write your evaluation as valid JSON to /tmp/validation-report.json — no markdo
 {
   "overall": "pass" | "warn" | "fail",
   "checks": {
+    "json_validity":     { "status": "pass|warn|fail", "notes": "..." },
     "twitter":           { "status": "pass|warn|fail", "char_count": <n>, "notes": "..." },
     "instagram_body":    { "status": "pass|warn|fail", "char_count": <n>, "notes": "..." },
     "instagram_hashtags": { "status": "pass|warn|fail", "hashtag_count": <n>, "notes": "..." },


### PR DESCRIPTION
Closes #301

## Summary
- Claude was writing unescaped double quotes inside JSON string values, breaking `jq` parsing in the Validate Claude output CI step
- Added explicit JSON escaping warning to `social-content.txt` — instruct Claude to rephrase rather than use double quotes inside string values
- Added `json_validity` as a hard constraint in `validate-output.txt`, including it in the validator output schema
- Verified locally — full pipeline passes cleanly including PDF generation

## Test plan
- [ ] Merge and verify next social post scheduled via Publer succeeds without a jq parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)