### PR TITLE
fix: add anchor id and header-anchor link to Planned posts heading

### DIFF
--- a/docs/.vitepress/theme/components/UpcomingPosts.vue
+++ b/docs/.vitepress/theme/components/UpcomingPosts.vue
@@ -87,7 +87,16 @@ onMounted(async () => {
   </p>
 
   <template v-else-if="!error">
-    <h2>Planned posts</h2>
+    <h2
+      id="planned-posts"
+      tabindex="-1"
+    >
+      Planned posts
+      <a
+        class="header-anchor"
+        href="#planned-posts"
+        aria-label="Permalink to &quot;Planned posts&quot;"
+      /></h2>
     <ul
       v-if="posts.length > 0"
       class="list-none p-0"


### PR DESCRIPTION
Closes #314

## Summary
- Add `id="planned-posts"` and `tabindex="-1"` to the Planned posts `<h2>` in `UpcomingPosts.vue`
- Add `.header-anchor` link so the heading behaves like VitePress markdown headings
- `/blog/#planned-posts` now scrolls to and highlights the section correctly

## Test plan
- [x] `/blog/#planned-posts` scrolls to the Planned posts section
- [x] Hash link icon appears on hover, matches other headings on the page
- [x] No visual change when not hovering

🤖 Generated with [Claude Code](https://claude.com/claude-code)