### PR TITLE
fix: add top margin to Planned sections block on upcoming post page

### DIFF
--- a/docs/.vitepress/theme/components/UpcomingPage.vue
+++ b/docs/.vitepress/theme/components/UpcomingPage.vue
@@ -304,7 +304,7 @@ onMounted(async () => {
       <!-- Planned sections -->
       <div
         v-if="post.sections.length > 0"
-        class="mb-10"
+        class="mt-10 mb-10"
       >
         <h2 class="!text-xl font-semibold mb-4 text-[var(--vp-c-text-1)] border-b border-[var(--vp-c-divider)] pb-2">
           Planned sections


### PR DESCRIPTION
Closes #316

## Summary
- Add `mt-10` to the Planned sections wrapper div in `UpcomingPage.vue` so there is visual breathing room between the summary paragraph and the "Planned sections" heading

## Test plan
- [x] Visit an upcoming post preview page (e.g. `/upcoming?issue=...`)
- [x] Confirm there is clear space above the "Planned sections" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)