### PR TITLE
fix: scroll to #planned-posts anchor after async render

### DIFF
--- a/docs/.vitepress/theme/components/UpcomingPosts.vue
+++ b/docs/.vitepress/theme/components/UpcomingPosts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 
 interface UpcomingPost {
   number: number
@@ -74,6 +74,10 @@ onMounted(async () => {
     error.value = true
   } finally {
     loading.value = false
+    if (window.location.hash === '#planned-posts') {
+      await nextTick()
+      document.getElementById('planned-posts')?.scrollIntoView()
+    }
   }
 })
 </script>


### PR DESCRIPTION
Closes #318

## Summary
- After the async GitHub fetch completes in `UpcomingPosts.vue`, check `window.location.hash` and manually scroll to `#planned-posts` once Vue has flushed the DOM via `nextTick`

## Test plan
- [x] Navigate to the blog page with `#planned-posts` in the URL
- [x] Confirm the page scrolls to the Planned posts heading

> Reported by Scott Basgaard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)