### PR TITLE
fix: correct anchor scroll for all headings after async content load

### DIFF
--- a/docs/.vitepress/theme/components/UpcomingPosts.vue
+++ b/docs/.vitepress/theme/components/UpcomingPosts.vue
@@ -74,9 +74,9 @@ onMounted(async () => {
     error.value = true
   } finally {
     loading.value = false
-    if (window.location.hash === '#planned-posts') {
+    if (window.location.hash) {
       await nextTick()
-      document.getElementById('planned-posts')?.scrollIntoView()
+      document.getElementById(window.location.hash.slice(1))?.scrollIntoView()
     }
   }
 })
@@ -100,7 +100,8 @@ onMounted(async () => {
         class="header-anchor"
         href="#planned-posts"
         aria-label="Permalink to &quot;Planned posts&quot;"
-      /></h2>
+      />
+    </h2>
     <ul
       v-if="posts.length > 0"
       class="list-none p-0"

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -109,6 +109,14 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Ensure anchored headings are not hidden behind the sticky nav */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.vp-doc h4 {
+  scroll-margin-top: var(--vp-nav-height);
+}
+
 /* Link hover effects */
 a {
   transition: color 200ms;


### PR DESCRIPTION
Closes #320

## Summary
- Generalise hash scroll in `UpcomingPosts.vue` from `#planned-posts` only to any `window.location.hash`, fixing displacement of all anchors after async content loads
- Add `scroll-margin-top: var(--vp-nav-height)` globally to all `.vp-doc` headings in `custom.css` so anchors land below the sticky nav site-wide
- Fix `vue/multiline-html-element-content-newline` lint warning on `</h2>` closing tag

## Test plan
- [ ] Navigate to `/blog#planned-posts` — confirm it scrolls correctly below the nav
- [ ] Navigate to `/blog#recent-posts` — confirm same behaviour
- [ ] Navigate to any blog post with a heading anchor — confirm no nav overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)