### PR TITLE
docs(readme): replace broken ../design/ links with BANCS-Norway/design references

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ BANCS uses a custom color palette based on our brand:
 --bancs-accent-alt: #8b5cf6 /* Purple accent */
 ```
 
-See [../design/](../design/) for complete brand guidelines.
+See [BANCS-Norway/design](https://github.com/BANCS-Norway/design) for complete brand guidelines (repo in progress).
 
 ## Deployment
 
@@ -194,7 +194,7 @@ See [LICENSE](./LICENSE) for details.
 - Built with [VitePress](https://vitepress.dev)
 - Styled with [Tailwind CSS](https://tailwindcss.com)
 - Deployed on [GitHub Pages](https://pages.github.com)
-- Logo design: See [../design/DESIGN-CONCEPT.md](../design/DESIGN-CONCEPT.md)
+- Logo design: BANCS internal design work, to be published at [BANCS-Norway/design](https://github.com/BANCS-Norway/design)
 - Site development assisted by [Claude](https://claude.ai) by Anthropic
 
 ---


### PR DESCRIPTION
Closes #331

## Summary
Two broken `../design/` links in README pointed at a local-only sibling directory that was never published. Now pointed at the (currently empty) `BANCS-Norway/design` repo as the intended future home.

## Test plan
- [x] Verify README renders on GitHub with no dead links
- [x] Both updated references click through to `https://github.com/BANCS-Norway/design`

🤖 Generated with [Claude Code](https://claude.com/claude-code)